### PR TITLE
Fixing concurrent access possibility on calendars resolution

### DIFF
--- a/internals/calendar/calendar.go
+++ b/internals/calendar/calendar.go
@@ -89,7 +89,7 @@ func setCalendar(calendar Calendar) {
 // - For each sub-calendar (with respect of order)
 //    - Sub-calendar Periods (with respect of order)
 // - Calendar Periods (with respect of order)
-func (c Calendar) ResolveCalendar(joinedCalendars []int64) Calendar {
+func (c Calendar) ResolveCalendar(enabledCalendars map[int64]Calendar, joinedCalendars []int64) Calendar {
 	joinedCalendars = append(joinedCalendars, c.ID)
 	periods := make([]Period, 0)
 
@@ -111,17 +111,13 @@ func (c Calendar) ResolveCalendar(joinedCalendars []int64) Calendar {
 			continue
 		}
 
-		unionCalendar, found, err := getCalendar(unionCalendarID)
+		unionCalendar, found := enabledCalendars[unionCalendarID]
 		if !found {
 			zap.L().Warn("The calendar to join was not found", zap.Int64("calendarID", c.ID), zap.Int64("unionedCalendarID", unionCalendarID))
 			continue
 		}
-		if err != nil {
-			zap.L().Error("Cannot get calendar", zap.Int64("calendarID", c.ID), zap.Int64("unionedCalendarID", unionCalendarID), zap.Error(err))
-			continue
-		}
 
-		unionCalendarResolved := unionCalendar.ResolveCalendar(joinedCalendars)
+		unionCalendarResolved := unionCalendar.ResolveCalendar(enabledCalendars, joinedCalendars)
 		periods = append(periods, unionCalendarResolved.Periods...)
 	}
 

--- a/internals/calendar/calendar_test.go
+++ b/internals/calendar/calendar_test.go
@@ -22,17 +22,16 @@ func initCalendars() {
 func TestCalendarResolution(t *testing.T) {
 	initCalendars()
 	c, _, _ := getCalendar(5)
-	resolved := c.ResolveCalendar([]int64{})
+	resolved := c.ResolveCalendar(_globalCBase.calendars, []int64{})
 
 	_ = resolved
 	t.Log(resolved)
-
 }
 
 func TestCalendarResolutionCircularReference(t *testing.T) {
 	initCalendars()
 	c, _, _ := getCalendar(6)
-	resolved := c.ResolveCalendar([]int64{})
+	resolved := c.ResolveCalendar(_globalCBase.calendars, []int64{})
 
 	_ = resolved
 	t.Log(resolved)
@@ -294,7 +293,7 @@ func TestUnionCalendarsSimpleCase(t *testing.T) {
 		UnionCalendarIDs: []int64{1}})
 
 	c, _, _ := getCalendar(2)
-	resolved := c.ResolveCalendar([]int64{})
+	resolved := c.ResolveCalendar(_globalCBase.calendars, []int64{})
 
 	if err := checkCalendarPeriod(t, resolved, time.Date(2022, 11, 23, 0, 0, 0, 0, time.UTC), true); err != nil {
 		t.Error(err)
@@ -330,7 +329,7 @@ func TestUnionCalendarsComplexeCase(t *testing.T) {
 		UnionCalendarIDs: []int64{1, 2, 3}})
 
 	c, _, _ := getCalendar(4)
-	resolved := c.ResolveCalendar([]int64{})
+	resolved := c.ResolveCalendar(_globalCBase.calendars, []int64{})
 
 	if err := checkCalendarPeriod(t, resolved, time.Date(2022, 11, 23, 0, 0, 0, 0, time.UTC), true); err != nil {
 		t.Error(err)


### PR DESCRIPTION
```
2023-01-13T00:00:00.036+0100 INFO flow/flow.go:53 START Indexing {"flow": "xxx", "checkcalendar": true, "status": "started"}
fatal error: concurrent map writes 
2023-01-13T00:00:00.036+0100 INFO flow/flow.go:53 START Indexing {"flow": "xxx", "checkcalendar": false, "status": "started"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa43366]goroutine 1072101 [running]:
github.com/myrteametrics/myrtea-engine-api/v5/internals/calendar.(*Node).isCyclic(0x0, 0xc0048f0540) 
github.com/myrteametrics/myrtea-engine-api/v5@v5.0.6/internals/calendar/graph.go:27 +0x26
github.com/myrteametrics/myrtea-engine-api/v5/internals/calendar.(*Base).Update(0xc000160190) 
github.com/myrteametrics/myrtea-engine-api/v5@v5.0.6/internals/calendar/calendar_base.go:89 +0x7dc
github.com/myrteametrics/myrtea-connector-api-colissimo-qssla/internals/flow.(*Flow).Run(0xc0001618b0) 
github.com/myrteametrics/myrtea-connector-api-colissimo-qssla/internals/flow/flow.go:48 +0x20b
github.com/myrteametrics/myrtea-connector-api-colissimo-qssla/internals/flow.FlowJob.Run({0xc000059630}) 
github.com/myrteametrics/myrtea-connector-api-colissimo-qssla/internals/flow/flow.go:31 +0x19
github.com/robfig/cron/v3.(*Cron).startJob.func1() github.com/robfig/cron/v3@v3.0.0/cron.go:307 +0x6a
created by github.com/robfig/cron/v3.(*Cron).startJob 
github.com/robfig/cron/v3@v3.0.0/cron.go:305 +0xb2
```