### PR TITLE
fix parsecomment error during build

### DIFF
--- a/internals/handlers/export_handlers.go
+++ b/internals/handlers/export_handlers.go
@@ -2,16 +2,17 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/export"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/fact"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/handlers/render"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/security/permissions"
 	"go.uber.org/zap"
-	"net/http"
-	"strconv"
-	"time"
-	"unicode/utf8"
 )
 
 type CSVParameters struct {
@@ -24,7 +25,7 @@ type CSVParameters struct {
 // @Summary Export facts
 // @Description Get all action definitions
 // @Tags ExportFact
-// @Produce file
+// @Produce octet-stream
 // @Security Bearer
 // @Success 200 {file} Returns data to be saved into a file
 // @Failure 500 "internal server error"


### PR DESCRIPTION
"@Produce file" provoked the following error during swagger docs creation, hence blocking the build process

swag init --generalInfo main.go
2023/06/09 09:05:05 Generate swagger docs....
2023/06/09 09:05:05 Generate general API Info
2023/06/09 09:05:05 ParseComment error in file internals/handlers/export_handlers.go :file produce type can't be accepted
make[2]: *** [Makefile:97: swag] Error 1
make[1]: *** [/home/hantran/Documents/github/myrtea-build-deploy/global/build/Makefile:27: code-build-golang] Error 2
make: *** [projets/shared/Makefile:32: build-engine] Error 2