### PR TITLE
Enable parsing of situation or situation instance parameters in handlers

### DIFF
--- a/internals/handlers/facts_handlers.go
+++ b/internals/handlers/facts_handlers.go
@@ -560,7 +560,7 @@ func GetFactHits(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		situationn, found, err := situation.R().Get(idSituation, parseGlobalVariables)
+		situationn, found, err := situation.R().Get(idSituation, gvalParsingEnabled(r.URL.Query()))
 		if err != nil {
 			zap.L().Error("Cannot retrieve situation", zap.Int64("situationID", idSituation), zap.Error(err))
 			render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -701,7 +701,7 @@ func FactToESQuery(w http.ResponseWriter, r *http.Request) {
 
 	parameters := make(map[string]string)
 	if situationid != 0 {
-		s, found, err := situation.R().Get(int64(situationid), parseGlobalVariables)
+		s, found, err := situation.R().Get(int64(situationid), gvalParsingEnabled(r.URL.Query()))
 		if err != nil {
 			render.Error(w, r, render.ErrAPIDBSelectFailed, err)
 			return

--- a/internals/handlers/rules_handlers_test.go
+++ b/internals/handlers/rules_handlers_test.go
@@ -159,7 +159,7 @@ func TestPostRulesSituations(t *testing.T) {
 	rr := tests.BuildTestHandler(t, "POST", "/rules/"+fmt.Sprint(r1ID)+"/situations", string(data), "/rules/{id}/situations", PostRuleSituations, user)
 	tests.CheckTestHandler(t, rr, http.StatusOK, ``)
 
-	getSituatations, _ := situation.R().GetAllByRuleID(int64(r1ID), parseGlobalVariables)
+	getSituatations, _ := situation.R().GetAllByRuleID(int64(r1ID), false)
 	if _, ok := getSituatations[s1ID]; !ok {
 		t.Errorf("The rule %d was not added to the rule list of the situation %d", r1ID, s1ID)
 	}
@@ -170,7 +170,7 @@ func TestPostRulesSituations(t *testing.T) {
 	rr = tests.BuildTestHandler(t, "POST", "/rules/"+fmt.Sprint(r2ID)+"/situations", string(data), "/rules/{id}/situations", PostRuleSituations, user)
 	tests.CheckTestHandler(t, rr, http.StatusOK, ``)
 
-	getSituatations, _ = situation.R().GetAllByRuleID(int64(r2ID), parseGlobalVariables)
+	getSituatations, _ = situation.R().GetAllByRuleID(int64(r2ID), false)
 	if _, ok := getSituatations[s1ID]; !ok {
 		t.Errorf("The rule %d was not added to the rule list of the situation %d", r1ID, s1ID)
 	}
@@ -193,7 +193,7 @@ func TestPostRulesSituations(t *testing.T) {
 	rr = tests.BuildTestHandler(t, "POST", "/rules/"+fmt.Sprint(r1ID)+"/situations", string(data), "/rules/{id}/situations", PostRuleSituations, user)
 	tests.CheckTestHandler(t, rr, http.StatusOK, ``)
 
-	getSituatations, _ = situation.R().GetAllByRuleID(int64(r1ID), parseGlobalVariables)
+	getSituatations, _ = situation.R().GetAllByRuleID(int64(r1ID), false)
 	if _, ok := getSituatations[s1ID]; !ok {
 		t.Errorf("The rule %d was not added to the rule list of the situation %d", r1ID, s1ID)
 	}
@@ -211,7 +211,7 @@ func TestPostRulesSituations(t *testing.T) {
 	rr = tests.BuildTestHandler(t, "POST", "/rules/"+fmt.Sprint(r1ID)+"/situations", string(data), "/rules/{id}/situations", PostRuleSituations, user)
 	tests.CheckTestHandler(t, rr, http.StatusOK, ``)
 
-	getSituatations, _ = situation.R().GetAllByRuleID(int64(r1ID), parseGlobalVariables)
+	getSituatations, _ = situation.R().GetAllByRuleID(int64(r1ID), false)
 	if _, ok := getSituatations[s1ID]; !ok {
 		t.Errorf("The rule %d was not added to the rule list of the situation %d", r1ID, s1ID)
 	}

--- a/internals/handlers/rules_linked_handlers.go
+++ b/internals/handlers/rules_linked_handlers.go
@@ -34,7 +34,7 @@ func GetRuleSituations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	situationsMap, err := situation.R().GetAllByRuleID(idRule, parseGlobalVariables)
+	situationsMap, err := situation.R().GetAllByRuleID(idRule, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Error on getting rule situations", zap.String("situationID", id), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -82,7 +82,7 @@ func PostRuleSituations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	situationsMap, err := situation.R().GetAllByRuleID(idRule, parseGlobalVariables)
+	situationsMap, err := situation.R().GetAllByRuleID(idRule, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Warn("Error getting situations by rulesID", zap.Int64("ruleID", idRule), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)

--- a/internals/handlers/situations_handlers.go
+++ b/internals/handlers/situations_handlers.go
@@ -34,10 +34,10 @@ func GetSituations(w http.ResponseWriter, r *http.Request) {
 	var situations map[int64]situation.Situation
 	var err error
 	if userCtx.HasPermission(permissions.New(permissions.TypeSituation, permissions.All, permissions.ActionGet)) {
-		situations, err = situation.R().GetAll(parseGlobalVariables)
+		situations, err = situation.R().GetAll(gvalParsingEnabled(r.URL.Query()))
 	} else {
 		resourceIDs := userCtx.GetMatchingResourceIDsInt64(permissions.New(permissions.TypeSituation, permissions.All, permissions.ActionGet))
-		situations, err = situation.R().GetAllByIDs(resourceIDs, parseGlobalVariables)
+		situations, err = situation.R().GetAllByIDs(resourceIDs, gvalParsingEnabled(r.URL.Query()))
 	}
 	if err != nil {
 		zap.L().Warn("Cannot retrieve situations", zap.Error(err))
@@ -81,7 +81,7 @@ func GetSituation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	situation, found, err := situation.R().Get(idSituation, parseGlobalVariables)
+	situation, found, err := situation.R().Get(idSituation, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Cannot retrieve situation", zap.Int64("situationID", idSituation), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -218,7 +218,7 @@ func PostSituation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	situation, found, err := situation.R().Get(idSituation, parseGlobalVariables)
+	situation, found, err := situation.R().Get(idSituation, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Cannot retrieve situation", zap.Int64("situationID", idSituation), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -283,7 +283,7 @@ func PutSituation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	situation, found, err := situation.R().Get(idSituation, parseGlobalVariables)
+	situation, found, err := situation.R().Get(idSituation, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Cannot retrieve situation", zap.Int64("situationID", idSituation), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)

--- a/internals/handlers/situations_linked_handlers.go
+++ b/internals/handlers/situations_linked_handlers.go
@@ -289,7 +289,7 @@ func PostSituationTemplateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, found, err := situation.R().GetTemplateInstance(instanceID, parseGlobalVariables)
+	instance, found, err := situation.R().GetTemplateInstance(instanceID, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Cannot retrieve situation template instance", zap.Int64("situationID", idSituation), zap.Int64("instanceID", instanceID), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -366,7 +366,7 @@ func PutSituationTemplateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, found, err := situation.R().GetTemplateInstance(instanceID, parseGlobalVariables)
+	instance, found, err := situation.R().GetTemplateInstance(instanceID, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Cannot retrieve situation template instance", zap.Int64("situationID", idSituation), zap.Int64("instanceID", instanceID), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -432,7 +432,7 @@ func PutSituationTemplateInstances(w http.ResponseWriter, r *http.Request) {
 		resolvedNewInstances = append(resolvedNewInstances, instance)
 	}
 
-	oldInstances, err := situation.R().GetAllTemplateInstances(idSituation, parseGlobalVariables)
+	oldInstances, err := situation.R().GetAllTemplateInstances(idSituation, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Error while getting existing situation template instances", zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)
@@ -566,12 +566,7 @@ func GetSituationTemplateInstances(w http.ResponseWriter, r *http.Request) {
 
 	// FIXME: security check !
 
-	gvalParsingEnabled, err := strconv.ParseBool(r.URL.Query().Get("parsinggvalenabled"))
-	if err != nil {
-		gvalParsingEnabled = false
-	}
-
-	instances, err := situation.R().GetAllTemplateInstances(idSituation, gvalParsingEnabled)
+	instances, err := situation.R().GetAllTemplateInstances(idSituation, gvalParsingEnabled(r.URL.Query()))
 	if err != nil {
 		zap.L().Error("Error on getting situation template instances", zap.String("situationID", id), zap.Error(err))
 		render.Error(w, r, render.ErrAPIDBSelectFailed, err)

--- a/internals/handlers/utils.go
+++ b/internals/handlers/utils.go
@@ -33,7 +33,6 @@ const (
 	IDTokenVerifyErr            = "OIDC authentication Failed to verify ID token"
 	TokenName                   = "token"
 	AllowedCookiePath           = "/"
-	parseGlobalVariables        = false
 	EnableParsingQueryParamName = "parsinggvalenabled"
 )
 

--- a/internals/handlers/utils.go
+++ b/internals/handlers/utils.go
@@ -26,15 +26,15 @@ import (
 )
 
 const (
-	ExpectedStateErr                = "Error to generate a random State for OIDC Authentification"
-	InvalidStateErr                 = "OIDC authentication invalid state"
-	TokenExchangeErr                = "OIDC authentication Failed to exchange token"
-	NoIDTokenErr                    = "OIDC authentication No ID token found"
-	IDTokenVerifyErr                = "OIDC authentication Failed to verify ID token"
-	TokenName                       = "token"
-	AllowedCookiePath               = "/"
-	parseGlobalVariables            = false
-	NameParmInQueryForEnableParsing = "parsinggvalenabled"
+	ExpectedStateErr            = "Error to generate a random State for OIDC Authentification"
+	InvalidStateErr             = "OIDC authentication invalid state"
+	TokenExchangeErr            = "OIDC authentication Failed to exchange token"
+	NoIDTokenErr                = "OIDC authentication No ID token found"
+	IDTokenVerifyErr            = "OIDC authentication Failed to verify ID token"
+	TokenName                   = "token"
+	AllowedCookiePath           = "/"
+	parseGlobalVariables        = false
+	EnableParsingQueryParamName = "parsinggvalenabled"
 )
 
 // QueryParamToOptionalInt parse a string from a string
@@ -310,7 +310,7 @@ func findCombineFacts(combineFactIds []int64) (combineFacts []engine.Fact) {
 }
 
 func gvalParsingEnabled(params url.Values) bool {
-	val := params.Get(NameParmInQueryForEnableParsing)
+	val := params.Get(EnableParsingQueryParamName)
 	if val == "" {
 		return false
 	}

--- a/internals/handlers/utils.go
+++ b/internals/handlers/utils.go
@@ -6,16 +6,18 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internals/fact"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internals/utils"
-	"github.com/myrteametrics/myrtea-sdk/v4/engine"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/myrteametrics/myrtea-engine-api/v5/internals/fact"
+	"github.com/myrteametrics/myrtea-engine-api/v5/internals/utils"
+	"github.com/myrteametrics/myrtea-sdk/v4/engine"
+
 	"net/http"
+	"net/url"
 
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/handlers/render"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/models"
@@ -24,14 +26,15 @@ import (
 )
 
 const (
-	ExpectedStateErr     = "Error to generate a random State for OIDC Authentification"
-	InvalidStateErr      = "OIDC authentication invalid state"
-	TokenExchangeErr     = "OIDC authentication Failed to exchange token"
-	NoIDTokenErr         = "OIDC authentication No ID token found"
-	IDTokenVerifyErr     = "OIDC authentication Failed to verify ID token"
-	TokenName            = "token"
-	AllowedCookiePath    = "/"
-	parseGlobalVariables = false
+	ExpectedStateErr                = "Error to generate a random State for OIDC Authentification"
+	InvalidStateErr                 = "OIDC authentication invalid state"
+	TokenExchangeErr                = "OIDC authentication Failed to exchange token"
+	NoIDTokenErr                    = "OIDC authentication No ID token found"
+	IDTokenVerifyErr                = "OIDC authentication Failed to verify ID token"
+	TokenName                       = "token"
+	AllowedCookiePath               = "/"
+	parseGlobalVariables            = false
+	NameParmInQueryForEnableParsing = "parsinggvalenabled"
 )
 
 // QueryParamToOptionalInt parse a string from a string
@@ -304,4 +307,16 @@ func findCombineFacts(combineFactIds []int64) (combineFacts []engine.Fact) {
 		combineFacts = append(combineFacts, combineFact)
 	}
 	return combineFacts
+}
+
+func gvalParsingEnabled(params url.Values) bool {
+	val := params.Get(NameParmInQueryForEnableParsing)
+	if val == "" {
+		return false
+	}
+	parsedVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return parsedVal
 }


### PR DESCRIPTION
In handlers that retrieve situation or situation instance data, allow the 'parsinggvalenable' parameter to be passed as an input. When this parameter is set to 'true', the parameters of the situation or situation instance will be parsed using gval. In all other cases, the parameters will not be parsed.