### PR TITLE
Added fact parameters to export

### DIFF
--- a/internals/export/elasticsearch.go
+++ b/internals/export/elasticsearch.go
@@ -27,7 +27,7 @@ func ExportFactHitsFull(f engine.Fact) ([]reader.Hit, error) {
 	}
 }
 
-func (export StreamedExport) StreamedExportFactHitsFull(ctx context.Context, f engine.Fact, limit int64, placeholders map[string]string) error {
+func (export StreamedExport) StreamedExportFactHitsFull(ctx context.Context, f engine.Fact, limit int64, factParameters map[string]string) error {
 	version := viper.GetInt("ELASTICSEARCH_VERSION")
 	switch version {
 	case 7:

--- a/internals/export/elasticsearch.go
+++ b/internals/export/elasticsearch.go
@@ -3,9 +3,10 @@ package export
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/myrteametrics/myrtea-sdk/v4/engine"
 	"github.com/spf13/viper"
-	"time"
 
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/reader"
 	"go.uber.org/zap"
@@ -26,13 +27,13 @@ func ExportFactHitsFull(f engine.Fact) ([]reader.Hit, error) {
 	}
 }
 
-func (export StreamedExport) StreamedExportFactHitsFull(ctx context.Context, f engine.Fact, limit int64) error {
+func (export StreamedExport) StreamedExportFactHitsFull(ctx context.Context, f engine.Fact, limit int64, placeholders map[string]string) error {
 	version := viper.GetInt("ELASTICSEARCH_VERSION")
 	switch version {
 	case 7:
 		fallthrough
 	case 8:
-		return export.StreamedExportFactHitsFullV8(ctx, f, limit)
+		return export.StreamedExportFactHitsFullV8(ctx, f, limit, placeholders)
 	default:
 		// No fatal here, 6 is unsupported
 		//zap.L().Fatal("Unsupported Elasticsearch version", zap.Int("version", version))

--- a/internals/export/elasticsearch.go
+++ b/internals/export/elasticsearch.go
@@ -33,7 +33,7 @@ func (export StreamedExport) StreamedExportFactHitsFull(ctx context.Context, f e
 	case 7:
 		fallthrough
 	case 8:
-		return export.StreamedExportFactHitsFullV8(ctx, f, limit, placeholders)
+		return export.StreamedExportFactHitsFullV8(ctx, f, limit, factParameters)
 	default:
 		// No fatal here, 6 is unsupported
 		//zap.L().Fatal("Unsupported Elasticsearch version", zap.Int("version", version))

--- a/internals/export/elasticsearchv8.go
+++ b/internals/export/elasticsearchv8.go
@@ -40,10 +40,8 @@ func (export StreamedExport) DrainChannel() {
 
 // StreamedExportFactHitsFullV8 export data from ElasticSearch to a channel
 // Please note that the channel is not closed when this function is executed
-func (export StreamedExport) StreamedExportFactHitsFullV8(ctx context.Context, f engine.Fact, limit int64) error {
+func (export StreamedExport) StreamedExportFactHitsFullV8(ctx context.Context, f engine.Fact, limit int64, placeholders map[string]string) error {
 	ti := time.Now()
-	placeholders := make(map[string]string)
-
 	// Change the behaviour of the Fact
 	f.Intent.Operator = engine.Select
 

--- a/internals/export/elasticsearchv8.go
+++ b/internals/export/elasticsearchv8.go
@@ -45,12 +45,12 @@ func (export StreamedExport) StreamedExportFactHitsFullV8(ctx context.Context, f
 	// Change the behaviour of the Fact
 	f.Intent.Operator = engine.Select
 
-	err := f.ContextualizeCondition(ti, placeholders)
+	err := f.ContextualizeCondition(ti, factParameters)
 	if err != nil {
 		return err
 	}
 
-	searchRequest, err := elasticsearchv8.ConvertFactToSearchRequestV8(f, ti, placeholders)
+	searchRequest, err := elasticsearchv8.ConvertFactToSearchRequestV8(f, ti, factParameters)
 	if err != nil {
 		zap.L().Error("ConvertFactToSearchRequestV8 failed", zap.Error(err))
 		return err

--- a/internals/export/elasticsearchv8.go
+++ b/internals/export/elasticsearchv8.go
@@ -40,7 +40,7 @@ func (export StreamedExport) DrainChannel() {
 
 // StreamedExportFactHitsFullV8 export data from ElasticSearch to a channel
 // Please note that the channel is not closed when this function is executed
-func (export StreamedExport) StreamedExportFactHitsFullV8(ctx context.Context, f engine.Fact, limit int64, placeholders map[string]string) error {
+func (export StreamedExport) StreamedExportFactHitsFullV8(ctx context.Context, f engine.Fact, limit int64, factParameters map[string]string) error {
 	ti := time.Now()
 	// Change the behaviour of the Fact
 	f.Intent.Operator = engine.Select

--- a/internals/export/worker.go
+++ b/internals/export/worker.go
@@ -162,7 +162,7 @@ func (e *ExportWorker) Start(item WrapperItem, ctx context.Context) {
 		defer close(streamedExport.Data)
 
 		for _, f := range item.Facts {
-			writerErr = streamedExport.StreamedExportFactHitsFull(ctx, f, item.Params.Limit, item.Placeholders)
+			writerErr = streamedExport.StreamedExportFactHitsFull(ctx, f, item.Params.Limit, item.FactParameters)
 			if writerErr != nil {
 				break // break here when error occurs?
 			}

--- a/internals/export/worker.go
+++ b/internals/export/worker.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internals/notifier"
-	"go.uber.org/zap"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/myrteametrics/myrtea-engine-api/v5/internals/notifier"
+	"go.uber.org/zap"
 )
 
 type ExportWorker struct {
@@ -161,7 +162,7 @@ func (e *ExportWorker) Start(item WrapperItem, ctx context.Context) {
 		defer close(streamedExport.Data)
 
 		for _, f := range item.Facts {
-			writerErr = streamedExport.StreamedExportFactHitsFull(ctx, f, item.Params.Limit)
+			writerErr = streamedExport.StreamedExportFactHitsFull(ctx, f, item.Params.Limit, item.Placeholders)
 			if writerErr != nil {
 				break // break here when error occurs?
 			}

--- a/internals/export/wrapper.go
+++ b/internals/export/wrapper.go
@@ -2,17 +2,18 @@ package export
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/notifier"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/security"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internals/security/users"
 	"github.com/myrteametrics/myrtea-sdk/v4/engine"
 	"go.uber.org/zap"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -40,16 +41,17 @@ const (
 
 // WrapperItem represents an export demand
 type WrapperItem struct {
-	Id       string        `json:"id"`      // unique id that represents an export demand
-	FactIDs  []int64       `json:"factIds"` // list of fact ids that are part of the export (for archive and json)
-	Facts    []engine.Fact `json:"-"`
-	Error    string        `json:"error"`
-	Status   int           `json:"status"`
-	FileName string        `json:"fileName"`
-	Title    string        `json:"title"`
-	Date     time.Time     `json:"date"`
-	Users    []string      `json:"-"`
-	Params   CSVParameters `json:"-"`
+	Id           string            `json:"id"`      // unique id that represents an export demand
+	FactIDs      []int64           `json:"factIds"` // list of fact ids that are part of the export (for archive and json)
+	Facts        []engine.Fact     `json:"-"`
+	Error        string            `json:"error"`
+	Status       int               `json:"status"`
+	FileName     string            `json:"fileName"`
+	Title        string            `json:"title"`
+	Date         time.Time         `json:"date"`
+	Users        []string          `json:"-"`
+	Params       CSVParameters     `json:"-"`
+	Placeholders map[string]string `json:"placeholders"`
 }
 
 type Wrapper struct {
@@ -76,7 +78,7 @@ type Wrapper struct {
 }
 
 // NewWrapperItem creates a new export wrapper item
-func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, user users.User) *WrapperItem {
+func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, user users.User, placeholders map[string]string) *WrapperItem {
 	var factIDs []int64
 	for _, fact := range facts {
 		factIDs = append(factIDs, fact.ID)
@@ -88,16 +90,17 @@ func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, use
 		strings.ReplaceAll(title, " ", "_") + ".csv.gz"
 
 	return &WrapperItem{
-		Users:    append([]string{}, user.Login),
-		Id:       uuid.New().String(),
-		Facts:    facts,
-		FactIDs:  factIDs,
-		Date:     time.Now(),
-		Status:   StatusPending,
-		Error:    "",
-		FileName: fileName,
-		Title:    title,
-		Params:   params,
+		Users:        append([]string{}, user.Login),
+		Id:           uuid.New().String(),
+		Facts:        facts,
+		FactIDs:      factIDs,
+		Date:         time.Now(),
+		Status:       StatusPending,
+		Error:        "",
+		FileName:     fileName,
+		Title:        title,
+		Params:       params,
+		Placeholders: placeholders,
 	}
 }
 
@@ -177,7 +180,7 @@ func factsEquals(a, b []engine.Fact) bool {
 }
 
 // AddToQueue Adds a new export to the export worker queue
-func (ew *Wrapper) AddToQueue(facts []engine.Fact, title string, params CSVParameters, user users.User) (*WrapperItem, int) {
+func (ew *Wrapper) AddToQueue(facts []engine.Fact, title string, params CSVParameters, user users.User, placeholders map[string]string) (*WrapperItem, int) {
 	ew.queueMutex.Lock()
 	defer ew.queueMutex.Unlock()
 
@@ -201,7 +204,7 @@ func (ew *Wrapper) AddToQueue(facts []engine.Fact, title string, params CSVParam
 		return nil, CodeQueueFull
 	}
 
-	item := NewWrapperItem(facts, title, params, user)
+	item := NewWrapperItem(facts, title, params, user, placeholders)
 	ew.queue = append(ew.queue, item)
 	return item, CodeAdded
 }

--- a/internals/export/wrapper.go
+++ b/internals/export/wrapper.go
@@ -51,7 +51,7 @@ type WrapperItem struct {
 	Date         time.Time         `json:"date"`
 	Users        []string          `json:"-"`
 	Params       CSVParameters     `json:"-"`
-	Placeholders map[string]string `json:"placeholders"`
+	FactParameters map[string]string `json:"factParameters"`
 }
 
 type Wrapper struct {
@@ -78,7 +78,7 @@ type Wrapper struct {
 }
 
 // NewWrapperItem creates a new export wrapper item
-func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, user users.User, placeholders map[string]string) *WrapperItem {
+func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, user users.User, factParameters map[string]string) *WrapperItem {
 	var factIDs []int64
 	for _, fact := range facts {
 		factIDs = append(factIDs, fact.ID)
@@ -100,7 +100,7 @@ func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, use
 		FileName:     fileName,
 		Title:        title,
 		Params:       params,
-		Placeholders: placeholders,
+		FactParameters: factParameters,
 	}
 }
 
@@ -180,7 +180,7 @@ func factsEquals(a, b []engine.Fact) bool {
 }
 
 // AddToQueue Adds a new export to the export worker queue
-func (ew *Wrapper) AddToQueue(facts []engine.Fact, title string, params CSVParameters, user users.User, placeholders map[string]string) (*WrapperItem, int) {
+func (ew *Wrapper) AddToQueue(facts []engine.Fact, title string, params CSVParameters, user users.User, factParameters map[string]string) (*WrapperItem, int) {
 	ew.queueMutex.Lock()
 	defer ew.queueMutex.Unlock()
 
@@ -204,7 +204,7 @@ func (ew *Wrapper) AddToQueue(facts []engine.Fact, title string, params CSVParam
 		return nil, CodeQueueFull
 	}
 
-	item := NewWrapperItem(facts, title, params, user, placeholders)
+	item := NewWrapperItem(facts, title, params, user, factParameters)
 	ew.queue = append(ew.queue, item)
 	return item, CodeAdded
 }

--- a/internals/handlers/export_handlers.go
+++ b/internals/handlers/export_handlers.go
@@ -319,9 +319,9 @@ func (e *ExportHandler) ExportFact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	factParametres, err := ParseFactParametres(r.URL.Query().Get("factParametres"))
+	factParameters, err := ParseFactParameters(r.URL.Query().Get("factParameters"))
 	if err != nil {
-		zap.L().Error("Parse input Fact Parametres", zap.Error(err), zap.String("raw offset", r.URL.Query().Get("factparametres")))
+		zap.L().Error("Parse input Fact Parametres", zap.Error(err), zap.String("raw offset", r.URL.Query().Get("factParameters")))
 		render.Error(w, r, render.ErrAPIParsingInteger, err)
 		return
 	}
@@ -333,7 +333,7 @@ func (e *ExportHandler) ExportFact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	item, status := e.exportWrapper.AddToQueue(facts, request.Title, request.CSVParameters, userCtx.User, factParametres)
+	item, status := e.exportWrapper.AddToQueue(facts, request.Title, request.CSVParameters, userCtx.User, factParameters)
 
 	switch status {
 	case export.CodeAdded:

--- a/internals/handlers/export_handlers.go
+++ b/internals/handlers/export_handlers.go
@@ -5,16 +5,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-chi/chi/v5"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internals/export"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internals/handlers/render"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internals/security/permissions"
-	"go.uber.org/zap"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"strconv"
 	"sync"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/myrteametrics/myrtea-engine-api/v5/internals/export"
+	"github.com/myrteametrics/myrtea-engine-api/v5/internals/handlers/render"
+	"github.com/myrteametrics/myrtea-engine-api/v5/internals/security/permissions"
+	"go.uber.org/zap"
 )
 
 type ExportHandler struct {
@@ -121,7 +122,7 @@ func handleStreamedExport(requestContext context.Context, w http.ResponseWriter,
 		defer close(streamedExport.Data)
 
 		for _, f := range facts {
-			writerErr = streamedExport.StreamedExportFactHitsFull(ctx, f, request.Limit)
+			writerErr = streamedExport.StreamedExportFactHitsFull(ctx, f, request.Limit, make(map[string]string))
 			if writerErr != nil {
 				zap.L().Error("Error during export (StreamedExportFactHitsFullV8)", zap.Error(err))
 				break // break here when error occurs?
@@ -318,6 +319,13 @@ func (e *ExportHandler) ExportFact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	factParametres, err := ParseFactParametres(r.URL.Query().Get("factParametres"))
+	if err != nil {
+		zap.L().Error("Parse input Fact Parametres", zap.Error(err), zap.String("raw offset", r.URL.Query().Get("factparametres")))
+		render.Error(w, r, render.ErrAPIParsingInteger, err)
+		return
+	}
+
 	facts := findCombineFacts(request.FactIDs)
 	if len(facts) == 0 {
 		zap.L().Warn("No fact was found in export request")
@@ -325,7 +333,7 @@ func (e *ExportHandler) ExportFact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	item, status := e.exportWrapper.AddToQueue(facts, request.Title, request.CSVParameters, userCtx.User)
+	item, status := e.exportWrapper.AddToQueue(facts, request.Title, request.CSVParameters, userCtx.User, factParametres)
 
 	switch status {
 	case export.CodeAdded:

--- a/internals/handlers/facts_handlers.go
+++ b/internals/handlers/facts_handlers.go
@@ -505,9 +505,9 @@ func GetFactHits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	factParametres, err := ParseFactParametres(r.URL.Query().Get("factParametres"))
+	factParameters, err := ParseFactParameters(r.URL.Query().Get("factParameters"))
 	if err != nil {
-		zap.L().Error("Parse input FactParametres", zap.Error(err), zap.String("raw offset", r.URL.Query().Get("factparametres")))
+		zap.L().Error("Parse input FactParametres", zap.Error(err), zap.String("raw offset", r.URL.Query().Get("factParameters")))
 		render.Error(w, r, render.ErrAPIParsingInteger, err)
 		return
 	}
@@ -613,7 +613,7 @@ func GetFactHits(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// parameters entered from the front-ends
-	for key, param := range factParametres {
+	for key, param := range factParameters {
 		placeholders[key] = param
 	}
 

--- a/internals/handlers/facts_handlers.go
+++ b/internals/handlers/facts_handlers.go
@@ -505,6 +505,13 @@ func GetFactHits(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	factParametres, err := ParseFactParametres(r.URL.Query().Get("factParametres"))
+	if err != nil {
+		zap.L().Error("Parse input FactParametres", zap.Error(err), zap.String("raw offset", r.URL.Query().Get("factparametres")))
+		render.Error(w, r, render.ErrAPIParsingInteger, err)
+		return
+	}
+
 	id := chi.URLParam(r, "id")
 	var f engine.Fact
 	var found bool
@@ -602,6 +609,12 @@ func GetFactHits(w http.ResponseWriter, r *http.Request) {
 		for key, param := range situationInstance.Parameters {
 			placeholders[key] = param
 		}
+
+	}
+
+	// parameters entered from the front-ends
+	for key, param := range factParametres {
+		placeholders[key] = param
 	}
 
 	// Change the behaviour of the Fact

--- a/internals/handlers/utils.go
+++ b/internals/handlers/utils.go
@@ -320,14 +320,14 @@ func gvalParsingEnabled(params url.Values) bool {
 	return parsedVal
 }
 
-// ParsefactParametres takes a string of encoded parameters and returns a map of these decoded parameters.
-func ParseFactParametres(factParametres string) (map[string]string, error) {
+// ParsefactParameters takes a string of encoded parameters and returns a map of these decoded parameters.
+func ParseFactParameters(factParameters string) (map[string]string, error) {
 
-	if factParametres == "" {
+	if factParameters == "" {
 		return make(map[string]string), nil
 	}
 
-	decodedValue, err := url.QueryUnescape(factParametres)
+	decodedValue, err := url.QueryUnescape(factParameters)
 
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode: %v", err)

--- a/internals/handlers/utils.go
+++ b/internals/handlers/utils.go
@@ -319,3 +319,33 @@ func gvalParsingEnabled(params url.Values) bool {
 	}
 	return parsedVal
 }
+
+// ParsefactParametres takes a string of encoded parameters and returns a map of these decoded parameters.
+func ParseFactParametres(factParametres string) (map[string]string, error) {
+
+	if factParametres == "" {
+		return make(map[string]string), nil
+	}
+
+	decodedValue, err := url.QueryUnescape(factParametres)
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode: %v", err)
+	}
+
+	paramsMap := make(map[string]string)
+
+	//Separation of key pairs = value
+	pairs := strings.Split(decodedValue, "&")
+	for _, pair := range pairs {
+		// Separation of key and value
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid pair: %v", pair)
+		}
+
+		paramsMap[kv[0]] = kv[1]
+	}
+
+	return paramsMap, nil
+}


### PR DESCRIPTION
Today, in order to execute a fact, she may need the situation parameters as well as the instances of the situation.

This commit adds that it is now possible to enter the necessary parameters for the fact directly from the user interface. This is due to the evolution to allow exporting while modifying the fact's execution parameters. This evolution does not affect the old functioning.