### PR TITLE
Fix es export query failure by removing explicit sort order

### DIFF
--- a/internals/export/elasticsearch.go
+++ b/internals/export/elasticsearch.go
@@ -251,7 +251,7 @@ func ExportFactHitsFull(f engine.Fact) ([]reader.Hit, error) {
 			//Index(indicesStr).
 			Size(10000).
 			Request(searchRequest).
-			Sort("_shard_doc:asc").
+			Sort("_shard_doc").
 			Do(context.Background())
 		if err != nil {
 			zap.L().Error("ES Search failed", zap.Error(err))


### PR DESCRIPTION
Encountered error: "status: 400, failed: [search_phase_execution_exception], reason: all shards failed". The error occurred in `export/elasticsearch.go:256`, causing the task to fail in `tasker/task.go:86`.