### PR TITLE
Fix inconsistent casing for versionId route parameter

### DIFF
--- a/internal/handler/rules_handler.go
+++ b/internal/handler/rules_handler.go
@@ -106,17 +106,20 @@ func GetRule(w http.ResponseWriter, r *http.Request) {
 
 // GetRuleByVersion godoc
 //
-//	@Summary		Get a rule
-//	@Description	Get a specific rule by it's ID
-//	@Tags			Rules
-//	@Produce		json
-//	@Param			id	path	string	true	"Rule ID"
-//	@Param			versionId	path	string	true	"Rule Version ID"
-//	@Security		Bearer
-//	@Security		ApiKeyAuth
-//	@Success		200	{object}	rule.Rule	"rule"
-//	@Failure		500	"internal server error"
-//	@Router			/engine/rules/{id}/versions/{versionId} [get]
+//	@Summary      Get a rule by version
+//	@Description   Get a specific rule by its ID and version ID
+//	@Tags        Rules
+//	@Produce      json
+//	@Param       id path   int true   "Rule ID"
+//	@Param       versionId  path   int true   "Rule Version ID"
+//	@Security     Bearer
+//	@Security     ApiKeyAuth
+//	@Success      200    {object}   rule.Rule  "rule"
+//	@Failure      400    "bad request - invalid parameters"
+//	@Failure      403    "forbidden - insufficient permissions"
+//	@Failure      404    "not found - rule does not exist"
+//	@Failure      500    "internal server error"
+//	@Router          /engine/rules/{id}/versions/{versionId} [get]
 func GetRuleByVersion(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	idRule, err := strconv.ParseInt(id, 10, 64)

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -122,7 +122,7 @@ func engineRouter(services Services) http.Handler {
 
 	r.Get("/rules", handler.GetRules)
 	r.Get("/rules/{id}", handler.GetRule)
-	r.Get("/rules/{id}/versions/{versionid}", handler.GetRuleByVersion)
+	r.Get("/rules/{id}/versions/{versionId}", handler.GetRuleByVersion)
 	r.Post("/rules/validate", handler.ValidateRule)
 	r.Post("/rules", handler.PostRule)
 	r.Put("/rules/{id}", handler.PutRule)


### PR DESCRIPTION
- Refine Swagger annotations for accurate parameter types and error responses
- Fix inconsistent casing in route URL parameter for `versionId`