### PR TITLE
Added support for exporting uncompressed csv files

### DIFF
--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/reader"
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/reader"
 
 	"go.uber.org/zap"
 )

--- a/internal/export/csv_test.go
+++ b/internal/export/csv_test.go
@@ -3,8 +3,9 @@ package export
 import (
 	"bytes"
 	csv2 "encoding/csv"
-	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/reader"
 	"testing"
+
+	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/reader"
 )
 
 func TestConvertHitsToCSV(t *testing.T) {

--- a/internal/export/elasticsearch.go
+++ b/internal/export/elasticsearch.go
@@ -3,10 +3,11 @@ package export
 import (
 	"context"
 	"errors"
-	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/fact"
-	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/reader"
 	"strings"
 	"time"
+
+	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/fact"
+	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/reader"
 
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"

--- a/internal/export/elasticsearch_test.go
+++ b/internal/export/elasticsearch_test.go
@@ -1,11 +1,12 @@
 package export
 
 import (
+	"testing"
+
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/fact"
 	situation2 "github.com/myrteametrics/myrtea-engine-api/v5/pkg/situation"
 	elasticsearchsdk "github.com/myrteametrics/myrtea-sdk/v5/elasticsearch"
-	"testing"
 
 	"github.com/myrteametrics/myrtea-engine-api/v5/internal/coordinator"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internal/modeler"

--- a/internal/export/notification.go
+++ b/internal/export/notification.go
@@ -2,8 +2,9 @@ package export
 
 import (
 	"encoding/json"
-	"github.com/myrteametrics/myrtea-engine-api/v5/internal/notifier/notification"
 	"reflect"
+
+	"github.com/myrteametrics/myrtea-engine-api/v5/internal/notifier/notification"
 )
 
 const (

--- a/internal/export/notification_test.go
+++ b/internal/export/notification_test.go
@@ -1,10 +1,11 @@
 package export
 
 import (
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internal/notifier/notification"
 	"github.com/myrteametrics/myrtea-sdk/v5/expression"
-	"testing"
 )
 
 func TestExportNotification(t *testing.T) {

--- a/internal/export/utils.go
+++ b/internal/export/utils.go
@@ -3,11 +3,11 @@ package export
 import "github.com/myrteametrics/myrtea-engine-api/v5/internal/notifier/notification"
 
 type CSVParameters struct {
-	Columns       []Column `json:"columns"`
-	Separator     string   `json:"separator"`
-	Limit         int64    `json:"limit"`
-	ListSeparator string   `json:"listSeparator"`
-	Gzipped       bool     `json:"gzipped"`
+	Columns            []Column `json:"columns"`
+	Separator          string   `json:"separator"`
+	Limit              int64    `json:"limit"`
+	ListSeparator      string   `json:"listSeparator"`
+	UncompressedOutput bool     `json:"uncompressedOutput"`
 }
 
 type Column struct {
@@ -38,7 +38,7 @@ func (p CSVParameters) Equals(params CSVParameters) bool {
 	if p.Limit != params.Limit {
 		return false
 	}
-	if p.Gzipped != params.Gzipped {
+	if p.UncompressedOutput != params.UncompressedOutput {
 		return false
 	}
 	for i, column := range p.Columns {

--- a/internal/export/utils.go
+++ b/internal/export/utils.go
@@ -7,6 +7,7 @@ type CSVParameters struct {
 	Separator     string   `json:"separator"`
 	Limit         int64    `json:"limit"`
 	ListSeparator string   `json:"listSeparator"`
+	Gzipped       bool     `json:"gzipped"`
 }
 
 type Column struct {
@@ -35,6 +36,9 @@ func (p CSVParameters) Equals(params CSVParameters) bool {
 		return false
 	}
 	if p.Limit != params.Limit {
+		return false
+	}
+	if p.Gzipped != params.Gzipped {
 		return false
 	}
 	for i, column := range p.Columns {

--- a/internal/export/utils_test.go
+++ b/internal/export/utils_test.go
@@ -1,8 +1,9 @@
 package export
 
 import (
-	"github.com/myrteametrics/myrtea-sdk/v5/expression"
 	"testing"
+
+	"github.com/myrteametrics/myrtea-sdk/v5/expression"
 )
 
 func TestColumnEquals_WithDifferentName(t *testing.T) {
@@ -65,4 +66,31 @@ func TestGetColumnsLabel_WithColumns(t *testing.T) {
 	expression.AssertEqual(t, len(labels), 2)
 	expression.AssertEqual(t, labels[0], "label1")
 	expression.AssertEqual(t, labels[1], "label2")
+}
+
+func TestCSVParametersEquals_WithGzippedDifference(t *testing.T) {
+	// Test that CSVParameters.Equals considers the Gzipped field
+	params1 := CSVParameters{
+		Separator: ",",
+		Limit:     1000,
+		Gzipped:   true,
+	}
+
+	params2 := CSVParameters{
+		Separator: ",",
+		Limit:     1000,
+		Gzipped:   false,
+	}
+
+	params3 := CSVParameters{
+		Separator: ",",
+		Limit:     1000,
+		Gzipped:   true,
+	}
+
+	// Should be different when Gzipped differs
+	expression.AssertEqual(t, params1.Equals(params2), false, "CSVParameters with different Gzipped values should not be equal")
+
+	// Should be equal when all fields including Gzipped are the same
+	expression.AssertEqual(t, params1.Equals(params3), true, "CSVParameters with same Gzipped values should be equal")
 }

--- a/internal/export/utils_test.go
+++ b/internal/export/utils_test.go
@@ -68,29 +68,29 @@ func TestGetColumnsLabel_WithColumns(t *testing.T) {
 	expression.AssertEqual(t, labels[1], "label2")
 }
 
-func TestCSVParametersEquals_WithGzippedDifference(t *testing.T) {
-	// Test that CSVParameters.Equals considers the Gzipped field
+func TestCSVParametersEquals_WithUncompressedOutputDifference(t *testing.T) {
+	// Test that CSVParameters.Equals considers the UncompressedOutput field
 	params1 := CSVParameters{
-		Separator: ",",
-		Limit:     1000,
-		Gzipped:   true,
+		Separator:          ",",
+		Limit:              1000,
+		UncompressedOutput: true,
 	}
 
 	params2 := CSVParameters{
-		Separator: ",",
-		Limit:     1000,
-		Gzipped:   false,
+		Separator:          ",",
+		Limit:              1000,
+		UncompressedOutput: false,
 	}
 
 	params3 := CSVParameters{
-		Separator: ",",
-		Limit:     1000,
-		Gzipped:   true,
+		Separator:          ",",
+		Limit:              1000,
+		UncompressedOutput: true,
 	}
 
-	// Should be different when Gzipped differs
-	expression.AssertEqual(t, params1.Equals(params2), false, "CSVParameters with different Gzipped values should not be equal")
+	// Should be different when UncompressedOutput differs
+	expression.AssertEqual(t, params1.Equals(params2), false, "CSVParameters with different UncompressedOutput values should not be equal")
 
-	// Should be equal when all fields including Gzipped are the same
-	expression.AssertEqual(t, params1.Equals(params3), true, "CSVParameters with same Gzipped values should be equal")
+	// Should be equal when all fields including UncompressedOutput are the same
+	expression.AssertEqual(t, params1.Equals(params3), true, "CSVParameters with same UncompressedOutput values should be equal")
 }

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -133,11 +133,20 @@ func (e *ExportWorker) Start(item WrapperItem, ctx context.Context) {
 	}
 	defer file.Close()
 
-	// opens a gzip writer
-	gzipWriter := gzip.NewWriter(file)
-	defer gzipWriter.Close()
+	var csvWriter *csv.Writer
+	var gzipWriter *gzip.Writer
 
-	csvWriter := csv.NewWriter(gzipWriter)
+	// Conditionally apply gzip compression based on the Gzipped parameter
+	if item.Params.Gzipped {
+		// opens a gzip writer
+		gzipWriter = gzip.NewWriter(file)
+		defer gzipWriter.Close()
+		csvWriter = csv.NewWriter(gzipWriter)
+	} else {
+		// write directly to file without compression
+		csvWriter = csv.NewWriter(file)
+	}
+
 	streamedExport := NewStreamedExport()
 	var wg sync.WaitGroup
 	var writerErr error
@@ -154,7 +163,7 @@ func (e *ExportWorker) Start(item WrapperItem, ctx context.Context) {
 	 *    - Export goroutine: each fact is processed one by one
 	 *      Each bulk of data is sent through a channel to the receiver
 	 *    - The receiver handles the incoming channel data and converts them to the CSV format
-	 *      After the conversion, the data is written and gzipped to a local file
+	 *      After the conversion, the data is written to a local file (optionally gzipped)
 	 */
 
 	go func() {
@@ -239,7 +248,9 @@ loop:
 		}
 
 		// close writer and file access before trying to delete file
-		_ = gzipWriter.Close()
+		if gzipWriter != nil {
+			_ = gzipWriter.Close()
+		}
 		_ = file.Close()
 
 		err = os.Remove(path)

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -136,8 +136,9 @@ func (e *ExportWorker) Start(item WrapperItem, ctx context.Context) {
 	var csvWriter *csv.Writer
 	var gzipWriter *gzip.Writer
 
-	// Conditionally apply gzip compression based on the Gzipped parameter
-	if item.Params.Gzipped {
+	// Conditionally apply gzip compression based on the UncompressedOutput parameter
+	// Gzip is enabled by default unless UncompressedOutput is true
+	if !item.Params.UncompressedOutput {
 		// opens a gzip writer
 		gzipWriter = gzip.NewWriter(file)
 		defer gzipWriter.Close()

--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -1,8 +1,9 @@
 package export
 
 import (
-	"github.com/myrteametrics/myrtea-sdk/v5/expression"
 	"testing"
+
+	"github.com/myrteametrics/myrtea-sdk/v5/expression"
 )
 
 func TestNewExportWorker(t *testing.T) {

--- a/internal/export/wrapper.go
+++ b/internal/export/wrapper.go
@@ -2,14 +2,15 @@ package export
 
 import (
 	"context"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
-	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/security/users"
-	sdksecurity "github.com/myrteametrics/myrtea-sdk/v5/security"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
+	"github.com/myrteametrics/myrtea-engine-api/v5/pkg/security/users"
+	sdksecurity "github.com/myrteametrics/myrtea-sdk/v5/security"
 
 	"github.com/google/uuid"
 	"github.com/myrteametrics/myrtea-engine-api/v5/internal/notifier"
@@ -96,13 +97,19 @@ func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, use
 	}
 
 	var fileName string
+	extension := ".csv"
+	if params.Gzipped {
+		extension = ".csv.gz"
+	}
+
 	if addHashPrefix {
-		// file extension should be gz
 		// add random string to avoid multiple files with same name
 		fileName = sdksecurity.RandStringWithCharset(5, randCharSet) + "_" +
-			strings.ReplaceAll(title, " ", "_") + ".csv.gz"
-	} else if !strings.HasSuffix(title, ".csv.gz") {
-		fileName = strings.ReplaceAll(title, " ", "_") + ".csv.gz"
+			strings.ReplaceAll(title, " ", "_") + extension
+	} else if params.Gzipped && !strings.HasSuffix(title, ".csv.gz") {
+		fileName = strings.ReplaceAll(title, " ", "_") + extension
+	} else if !params.Gzipped && !strings.HasSuffix(title, ".csv") {
+		fileName = strings.ReplaceAll(title, " ", "_") + extension
 	} else {
 		fileName = strings.ReplaceAll(title, " ", "_")
 	}

--- a/internal/export/wrapper.go
+++ b/internal/export/wrapper.go
@@ -98,7 +98,7 @@ func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, use
 
 	var fileName string
 	extension := ".csv"
-	if params.Gzipped {
+	if !params.UncompressedOutput {
 		extension = ".csv.gz"
 	}
 
@@ -106,9 +106,9 @@ func NewWrapperItem(facts []engine.Fact, title string, params CSVParameters, use
 		// add random string to avoid multiple files with same name
 		fileName = sdksecurity.RandStringWithCharset(5, randCharSet) + "_" +
 			strings.ReplaceAll(title, " ", "_") + extension
-	} else if params.Gzipped && !strings.HasSuffix(title, ".csv.gz") {
+	} else if !params.UncompressedOutput && !strings.HasSuffix(title, ".csv.gz") {
 		fileName = strings.ReplaceAll(title, " ", "_") + extension
-	} else if !params.Gzipped && !strings.HasSuffix(title, ".csv") {
+	} else if params.UncompressedOutput && !strings.HasSuffix(title, ".csv") {
 		fileName = strings.ReplaceAll(title, " ", "_") + extension
 	} else {
 		fileName = strings.ReplaceAll(title, " ", "_")


### PR DESCRIPTION
This pull request introduces support for generating uncompressed CSV exports in addition to the existing gzipped (compressed) format. The main change is the addition of a new `UncompressedOutput` parameter in `CSVParameters`, which controls whether the exported CSV file is gzipped or not. The implementation updates the export worker logic, file naming conventions, and adds comprehensive tests to ensure correct behavior for both compressed and uncompressed outputs.

**CSV Export Compression Control:**

* Added a new `UncompressedOutput` boolean field to the `CSVParameters` struct, allowing users to specify whether the CSV export should be gzipped or left uncompressed. The default behavior remains gzipped unless `UncompressedOutput` is set to true.
* Updated the export worker logic in `worker.go` to conditionally apply gzip compression based on the new parameter, and ensured proper resource cleanup for both modes. [[1]](diffhunk://#diff-a1c7a117705c9f9e44c20597905f11068b1cf054d2081cb3a801bba132d308a0R136-L140) [[2]](diffhunk://#diff-a1c7a117705c9f9e44c20597905f11068b1cf054d2081cb3a801bba132d308a0R252-R254)
* Modified the file naming logic in `wrapper.go` so that uncompressed exports use the `.csv` extension and compressed exports use `.csv.gz`, including cases with hash prefixes and existing extensions.
* Enhanced equality checks for `CSVParameters` to compare the new `UncompressedOutput` field, ensuring correct behavior in logic and tests.
* Added and updated tests in `wrapper_test.go`, `utils_test.go`, and other test files to verify correct filename generation, export logic, and parameter equality for both compressed and uncompressed exports. [[1]](diffhunk://#diff-a6403e3f64a6faa55e57c7630023adb6f9684bea8c07269c841ec3bccfe9d0deL38-R67) [[2]](diffhunk://#diff-a6403e3f64a6faa55e57c7630023adb6f9684bea8c07269c841ec3bccfe9d0deR496-R524) [[3]](diffhunk://#diff-58c7208ec887fd8ef9c60352ecf0cea0af792eefc455ab621e73b3c5fbc27602R70-R96)

**General Code Cleanup:**

* Refactored import statements in multiple files for improved readability and consistency. [[1]](diffhunk://#diff-00bca05f586937c590d1f5f7a20934ce2818c6bbfba367c1723a9f954e9e6f86L7-R12) [[2]](diffhunk://#diff-12c4983982d50183ac420da87c8c5d5f6caf5e0b60c1fa0717ba2de9881cf35fL6-R8) [[3]](diffhunk://#diff-9527f64daacd8dc3cf44b30d1d2f5d4f90b7c7d0cb4b0ebf56d5d0d129d44529L6-R11) [[4]](diffhunk://#diff-30f4595f3cf201a3627761f5afa7858ac3961d0a61d5b91e5ae4dc12d9738c59L5-R7) [[5]](diffhunk://#diff-da914f579922866e897176c6b04c6e896886b007bce3f4f5fd8c7f8c922acd38L5-R14) [[6]](diffhunk://#diff-a6403e3f64a6faa55e57c7630023adb6f9684bea8c07269c841ec3bccfe9d0deL6-R14) [[7]](diffhunk://#diff-cfd638f8f852c42c96fe58a7a92030e684c4c8cca1c832e46203863ab276d053R4-L8) [[8]](diffhunk://#diff-58c7208ec887fd8ef9c60352ecf0cea0af792eefc455ab621e73b3c5fbc27602L4-R6) [[9]](diffhunk://#diff-3ee303665e86ecf854be779a2a65463e2f3eeefd2e5c088eb667ec1e151e3380L4-R6) [[10]](diffhunk://#diff-14957d940ec0be132c022f5ead1cd4308582a6c98a04c7861f3a91ef7acdc84eR4-L7)

These changes make the CSV export functionality more flexible and robust, allowing users to choose between compressed and uncompressed outputs as needed.