### PR TITLE
Boost mode system to accelerate and decelerate fact calculation scheduling 

### DIFF
--- a/internal/handler/facts_handler.go
+++ b/internal/handler/facts_handler.go
@@ -944,7 +944,7 @@ func FactToESQuery(w http.ResponseWriter, r *http.Request) {
 	f.ContextualizeDimensions(t)
 	err = f.ContextualizeCondition(t, parameters)
 	if err != nil {
-		httputil.Error(w, r, apiError, err)
+		httputil.Error(w, r, httputil.ErrAPIResourceInvalid, err)
 		return
 	}
 

--- a/internal/model/aggregation.go
+++ b/internal/model/aggregation.go
@@ -1,10 +1,11 @@
 package model
 
 type JobBoostInfo struct {
-	JobID      string `json:"jobId"`
-	Configured bool   `json:"configured"` // Is boost configured for this job?
-	Active     bool   `json:"active"`     // Is boost currently active?
-	Frequency  string `json:"frequency"`  // JobBoostInfo cron expression (e.g. "*/1 * * * *")
-	Quota      int    `json:"quota"`      // Max executions in boost mode
-	Used       int    `json:"used"`       // Executions completed in boost mode
+	JobID        string `json:"jobId"`
+	Configured   bool   `json:"configured"` // Is boost configured for this job?
+	Active       bool   `json:"active"`     // Is boost currently active?
+	Frequency    string `json:"frequency"`  // JobBoostInfo cron expression (e.g. "*/1 * * * *")
+	Quota        int    `json:"quota"`      // Max executions in boost mode
+	Used         int    `json:"used"`       // Executions completed in boost mode
+	DirectSwitch bool   `json:"-"`          // Runtime-only flag: switch scheduler mode directly without queueing boost/revert actions.
 }

--- a/internal/model/aggregation.go
+++ b/internal/model/aggregation.go
@@ -1,9 +1,10 @@
 package model
 
 type JobBoostInfo struct {
-	JobID     string `json:"jobId"`
-	Active    bool   `json:"active"`    // Is boost currently active?
-	Frequency string `json:"frequency"` // JobBoostInfo cron expression (e.g. "*/1 * * * *")
-	Quota     int    `json:"quota"`     // Max executions in boost mode
-	Used      int    `json:"used"`      // Executions completed in boost mode
+	JobID      string `json:"jobId"`
+	Configured bool   `json:"configured"` // Is boost configured for this job?
+	Active     bool   `json:"active"`     // Is boost currently active?
+	Frequency  string `json:"frequency"`  // JobBoostInfo cron expression (e.g. "*/1 * * * *")
+	Quota      int    `json:"quota"`      // Max executions in boost mode
+	Used       int    `json:"used"`       // Executions completed in boost mode
 }

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -610,15 +610,21 @@ func CalculateAndPersistSituations(localRuleEngine *ruleeng.RuleEngine, situatio
 		}
 	}
 
-	filteredTaskBatch := filterTaskByDependency(situationsToUpdate, situationHistoryMetadata, taskBatchsMap)
+	filteredTaskBatch := filterTask(situationsToUpdate, situationHistoryMetadata, taskBatchsMap)
 
 	return filteredTaskBatch, nil
 }
 
 // filtration
-func filterTaskByDependency(situationsToUpdate map[string]history.HistoryRecordV4, situationHistoryMetadata map[model.Key]map[string]interface{}, taskBatchsMap map[string]tasker.TaskBatch) []tasker.TaskBatch {
+func filterTask(situationsToUpdate map[string]history.HistoryRecordV4, situationHistoryMetadata map[model.Key]map[string]interface{}, taskBatchsMap map[string]tasker.TaskBatch) []tasker.TaskBatch {
 	filteredTaskBatch := make(map[string]tasker.TaskBatch, len(taskBatchsMap))
 	for key, taskBatch := range taskBatchsMap {
+		info := taskBatch.JobBoostInfo
+
+		if info != nil && info.Active && info.Quota < info.Used {
+			zap.L().Info("Task ignored due to boost mode active and quota not reached", zap.Any("task", taskBatch))
+			continue
+		}
 		filteredTaskBatch[key] = taskBatch
 	}
 

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -136,15 +136,14 @@ func (job FactCalculationJob) Run() {
 		return
 	}
 
-	runtimeJob := job
-	if job.JobBoostInfo != nil {
-		boostCopy := *job.JobBoostInfo
-		boostCopy.DirectSwitch = true
-		boostCopy.Used++
-		runtimeJob.JobBoostInfo = &boostCopy
+	if jbi := job.JobBoostInfo; jbi != nil {
+		jbi.DirectSwitch = true
+		if jbi.Active {
+			jbi.Used++
+		}
 	}
 
-	situationsToUpdate, err := CalculateAndPersistFacts(t, runtimeJob)
+	situationsToUpdate, err := CalculateAndPersistFacts(t, job)
 	if err != nil {
 		zap.L().Error("CalculateAndPersistFacts", zap.Error(err))
 		S().RemoveRunningJob(job.ScheduleID)

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -90,7 +90,7 @@ func (job FactCalculationJob) IsValid() (bool, error) {
 	if len(job.FactIds) <= 0 {
 		return false, errors.New("missing FactIds")
 	}
-	if job.JobBoostInfo != nil {
+	if boostConfigured(job.JobBoostInfo) {
 		if job.JobBoostInfo.Quota <= 0 {
 			return false, errors.New("invalid JobBoostInfo.Quota")
 		}
@@ -136,7 +136,7 @@ func (job FactCalculationJob) Run() {
 		return
 	}
 
-	situationsToUpdate, err := CalculateAndPersistFacts(t, job.FactIds)
+	situationsToUpdate, err := CalculateAndPersistFacts(t, job)
 	if err != nil {
 		zap.L().Error("CalculateAndPersistFacts", zap.Error(err))
 		S().RemoveRunningJob(job.ScheduleID)
@@ -335,10 +335,10 @@ func ReceiveAndPersistFacts(aggregates []ExternalAggregate) (map[string]history.
 	return situationsToUpdate, nil
 }
 
-func CalculateAndPersistFacts(t time.Time, factIDs []int64) (map[string]history.HistoryRecordV4, error) {
+func CalculateAndPersistFacts(t time.Time, job FactCalculationJob) (map[string]history.HistoryRecordV4, error) {
 	situationsToUpdate := make(map[string]history.HistoryRecordV4)
 
-	for _, factID := range factIDs {
+	for _, factID := range job.FactIds {
 		f, found, err := fact.R().Get(factID)
 		if err != nil {
 			zap.L().Error("Error Getting the Fact, skipping fact calculation...", zap.Int64("factID", factID))
@@ -392,6 +392,7 @@ func CalculateAndPersistFacts(t time.Time, factIDs []int64) (map[string]history.
 						HistoryFacts:        []history.HistoryFactsV4{historyFactNew},
 						EnableDependsOn:     sh.EnableDependsOn,
 						DependsOnParameters: sh.DependsOnParameters,
+						JobBoostInfo:        job.JobBoostInfo,
 					}
 				} else {
 					situation := situationsToUpdate[key]
@@ -440,6 +441,7 @@ func CalculateAndPersistFacts(t time.Time, factIDs []int64) (map[string]history.
 						HistoryFacts:        []history.HistoryFactsV4{historyFactNew},
 						EnableDependsOn:     sh.EnableDependsOn,
 						DependsOnParameters: sh.DependsOnParameters,
+						JobBoostInfo:        job.JobBoostInfo,
 					}
 				} else {
 					situation := situationsToUpdate[key]
@@ -838,4 +840,11 @@ func (job *FactCalculationJob) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+func boostConfigured(info *model.JobBoostInfo) bool {
+	if info == nil {
+		return false
+	}
+	return info.Configured
 }

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -98,7 +98,7 @@ func (job FactCalculationJob) IsValid() (bool, error) {
 			return false, errors.New("missing JobBoostInfo.Frequency")
 		}
 		if _, err := cronParser.Parse(job.JobBoostInfo.Frequency); err != nil {
-			return false, errors.New("invalid JobBoostInfo.Frequency" + err.Error())
+			return false, fmt.Errorf("invalid JobBoostInfo.Frequency: %w", err)
 		}
 	}
 	return true, nil

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -623,7 +623,7 @@ func filterTask(situationsToUpdate map[string]history.HistoryRecordV4, situation
 	for key, taskBatch := range taskBatchsMap {
 		info := taskBatch.JobBoostInfo
 
-		if info != nil && info.Active && info.Quota < info.Used {
+		if info != nil && info.Active && info.Used < info.Quota {
 			ignoredActions := extractIgnoredActionNames(taskBatch)
 			zap.L().Info(
 				"Task batch ignored: boost quota reached while boost mode is active",

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -634,7 +634,7 @@ func filterTask(situationsToUpdate map[string]history.HistoryRecordV4, situation
 		if info != nil && info.Active && info.Used < info.Quota {
 			ignoredActions := extractIgnoredActionNames(taskBatch)
 			zap.L().Info(
-				"Task batch ignored: boost quota reached while boost mode is active",
+				"Task batch ignored: boost quota not yet exhausted",
 				zap.String("taskBatchKey", key),
 				zap.Int("quota", info.Quota),
 				zap.Int("used", info.Used),
@@ -885,6 +885,13 @@ func (job *FactCalculationJob) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// boostConfigured returns true only if the job is explicitly configured to allow boost.
+//
+// Note: "Configured" does NOT mean boost is active at runtime.
+// It only indicates that boost is allowed for this job.
+// A value of false (or missing, e.g., legacy configs) means boost is ignored by default.
+//
+// Runtime activation still depends on boost logic (quota, conditions, etc.).
 func boostConfigured(info *model.JobBoostInfo) bool {
 	if info == nil {
 		return false

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -29,12 +29,13 @@ const timeLayout = "2006-01-02T15:04:05.000Z07:00"
 // FactCalculationJob represent a scheduler job instance which process a group of facts, and persist the result in postgresql
 // It also generate situations, persists them and notify the rule engine to evaluate them
 type FactCalculationJob struct {
-	FactIds        []int64 `json:"factIds"`
-	From           string  `json:"from,omitempty"`
-	To             string  `json:"to,omitempty"`
-	LastDailyValue bool    `json:"lastDailyValue,omitempty"`
-	Debug          bool    `json:"debug"`
-	ScheduleID     int64   `json:"-"`
+	FactIds        []int64             `json:"factIds"`
+	From           string              `json:"from,omitempty"`
+	To             string              `json:"to,omitempty"`
+	LastDailyValue bool                `json:"lastDailyValue,omitempty"`
+	JobBoostInfo   *model.JobBoostInfo `json:"jobboostinfo,omitempty"`
+	Debug          bool                `json:"debug"`
+	ScheduleID     int64               `json:"-"`
 }
 
 // ResolveFromAndTo resolves the expressions in parameters From and To
@@ -88,6 +89,17 @@ func (job FactCalculationJob) IsValid() (bool, error) {
 	}
 	if len(job.FactIds) <= 0 {
 		return false, errors.New("missing FactIds")
+	}
+	if job.JobBoostInfo != nil {
+		if job.JobBoostInfo.Quota <= 0 {
+			return false, errors.New("invalid JobBoostInfo.Quota")
+		}
+		if job.JobBoostInfo.Frequency == "" {
+			return false, errors.New("missing JobBoostInfo.Frequency")
+		}
+		if _, err := cronParser.Parse(job.JobBoostInfo.Frequency); err != nil {
+			return false, errors.New("invalid JobBoostInfo.Frequency" + err.Error())
+		}
 	}
 	return true, nil
 }

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -33,7 +33,7 @@ type FactCalculationJob struct {
 	From           string              `json:"from,omitempty"`
 	To             string              `json:"to,omitempty"`
 	LastDailyValue bool                `json:"lastDailyValue,omitempty"`
-	JobBoostInfo   *model.JobBoostInfo `json:"jobboostinfo,omitempty"`
+	JobBoostInfo   *model.JobBoostInfo `json:"jobBoostInfo,omitempty"`
 	Debug          bool                `json:"debug"`
 	ScheduleID     int64               `json:"-"`
 }

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -506,6 +506,8 @@ func CalculateAndPersistSituations(localRuleEngine *ruleeng.RuleEngine, situatio
 			zap.L().Error("", zap.Error(err))
 		}
 
+		// "set" actions are metadata-only; they are intentionally excluded from ignored-actions ,
+		// because dependency and boost filtering decisions app
 		metadatas := make([]metadata.MetaData, 0)
 		agenda := evaluator.EvaluateRules(localRuleEngine, historySituationFlattenData, enabledRuleIDs)
 		var filteredAgenda []ruleeng.Action
@@ -622,7 +624,14 @@ func filterTask(situationsToUpdate map[string]history.HistoryRecordV4, situation
 		info := taskBatch.JobBoostInfo
 
 		if info != nil && info.Active && info.Quota < info.Used {
-			zap.L().Info("Task ignored due to boost mode active and quota not reached", zap.Any("task", taskBatch))
+			ignoredActions := extractIgnoredActionNames(taskBatch)
+			zap.L().Info(
+				"Task batch ignored: boost quota reached while boost mode is active",
+				zap.String("taskBatchKey", key),
+				zap.Int("quota", info.Quota),
+				zap.Int("used", info.Used),
+				zap.Strings("ignoredActions", ignoredActions),
+			)
 			continue
 		}
 		filteredTaskBatch[key] = taskBatch
@@ -711,6 +720,19 @@ func filterTask(situationsToUpdate map[string]history.HistoryRecordV4, situation
 	}
 
 	return taskBatchSlice
+}
+
+func extractIgnoredActionNames(taskBatch tasker.TaskBatch) []string {
+	ignored := make([]string, 0, len(taskBatch.Agenda))
+	for _, action := range taskBatch.Agenda {
+		actionName := action.GetName()
+		// "set" actions are metadata-only and intentionally excluded from ignored action logs.
+		if actionName == ActionSetValue || actionName == tasker.ActionSet {
+			continue
+		}
+		ignored = append(ignored, actionName)
+	}
+	return ignored
 }
 
 func filterAgendaAndUpdateHistory(keychild string, DependsOnMetadata string, filteredTaskBatch map[string]tasker.TaskBatch, situationHistoryMetadata map[model.Key]map[string]interface{}, situation history.HistoryRecordV4) error {

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -466,6 +466,8 @@ func CalculateAndPersistSituations(localRuleEngine *ruleeng.RuleEngine, situatio
 	taskBatchs := make([]tasker.TaskBatch, 0)
 	taskBatchsMap := make(map[string]tasker.TaskBatch)
 	situationHistoryMetadata := make(map[model.Key]map[string]interface{})
+	allMetadatas := make([]metadata.MetaData, 0)
+	var aggregatedBoostInfo *model.JobBoostInfo
 	for _, situationToUpdate := range situationsToUpdate {
 
 		// zap.L().Sugar().Info(situationToUpdate)
@@ -506,8 +508,6 @@ func CalculateAndPersistSituations(localRuleEngine *ruleeng.RuleEngine, situatio
 			zap.L().Error("", zap.Error(err))
 		}
 
-		// "set" actions are metadata-only; they are intentionally excluded from ignored-actions ,
-		// because dependency and boost filtering decisions app
 		metadatas := make([]metadata.MetaData, 0)
 		agenda := evaluator.EvaluateRules(localRuleEngine, historySituationFlattenData, enabledRuleIDs)
 		var filteredAgenda []ruleeng.Action
@@ -569,10 +569,11 @@ func CalculateAndPersistSituations(localRuleEngine *ruleeng.RuleEngine, situatio
 		historySituationNew.ID, err = history.S().HistorySituationsQuerier.Insert(historySituationNew)
 		if err != nil {
 			zap.L().Error("", zap.Error(err))
-		} else {
-			if situationToUpdate.JobBoostInfo != nil {
-				JBM().Evaluate(metadatas, *situationToUpdate.JobBoostInfo)
-			}
+		}
+		allMetadatas = append(allMetadatas, metadatas...)
+		if aggregatedBoostInfo == nil && situationToUpdate.JobBoostInfo != nil {
+			boostCopy := *situationToUpdate.JobBoostInfo
+			aggregatedBoostInfo = &boostCopy
 		}
 		// zap.L().Sugar().Info("insert new situation", historySituationNew)
 
@@ -610,6 +611,13 @@ func CalculateAndPersistSituations(localRuleEngine *ruleeng.RuleEngine, situatio
 			key := fmt.Sprintf("%v-%v", situationToUpdate.SituationID, situationToUpdate.SituationInstanceID)
 			taskBatchsMap[key] = newTaskBatch
 		}
+	}
+
+	// Evaluate once per scheduler run with aggregated metadata from all updated instance situation.
+	// Attention: if a job updates multiple situation instances in one run, a single "critical"
+	// metadata is enough to trigger boost mode for the whole job.
+	if aggregatedBoostInfo != nil {
+		JBM().Evaluate(allMetadatas, *aggregatedBoostInfo)
 	}
 
 	filteredTaskBatch := filterTask(situationsToUpdate, situationHistoryMetadata, taskBatchsMap)

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -136,7 +136,15 @@ func (job FactCalculationJob) Run() {
 		return
 	}
 
-	situationsToUpdate, err := CalculateAndPersistFacts(t, job)
+	runtimeJob := job
+	if job.JobBoostInfo != nil {
+		boostCopy := *job.JobBoostInfo
+		boostCopy.DirectSwitch = true
+		boostCopy.Used++
+		runtimeJob.JobBoostInfo = &boostCopy
+	}
+
+	situationsToUpdate, err := CalculateAndPersistFacts(t, runtimeJob)
 	if err != nil {
 		zap.L().Error("CalculateAndPersistFacts", zap.Error(err))
 		S().RemoveRunningJob(job.ScheduleID)

--- a/internal/scheduler/fact_calculation_job.go
+++ b/internal/scheduler/fact_calculation_job.go
@@ -848,3 +848,39 @@ func boostConfigured(info *model.JobBoostInfo) bool {
 	}
 	return info.Configured
 }
+
+func asFactCalculationJob(job InternalJob) (FactCalculationJob, bool) {
+	switch typedJob := job.(type) {
+	case FactCalculationJob:
+		return typedJob, true
+	case *FactCalculationJob:
+		if typedJob == nil {
+			return FactCalculationJob{}, false
+		}
+		return *typedJob, true
+	default:
+		return FactCalculationJob{}, false
+	}
+}
+
+func extractFactCalculationJob(schedule InternalSchedule) (FactCalculationJob, bool) {
+	switch typedJob := schedule.Job.(type) {
+	case FactCalculationJob:
+		return typedJob, true
+	case *FactCalculationJob:
+		if typedJob == nil {
+			return FactCalculationJob{}, false
+		}
+		return *typedJob, true
+	default:
+		return FactCalculationJob{}, false
+	}
+}
+
+func isFactBoostManagedSchedule(schedule InternalSchedule) bool {
+	if schedule.JobType != "fact" {
+		return false
+	}
+	factJob, ok := extractFactCalculationJob(schedule)
+	return ok && boostConfigured(factJob.JobBoostInfo)
+}

--- a/internal/scheduler/job.go
+++ b/internal/scheduler/job.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
@@ -87,6 +88,9 @@ func UnmarshalInternalJob(t string, b json.RawMessage, scheduleID int64) (Intern
 		var tJob FactCalculationJob
 		err = json.Unmarshal(b, &tJob)
 		tJob.ScheduleID = scheduleID
+		if tJob.JobBoostInfo != nil && tJob.JobBoostInfo.JobID == "" {
+			tJob.JobBoostInfo.JobID = strconv.FormatInt(scheduleID, 10)
+		}
 		job = tJob
 
 	case "baseline":

--- a/internal/scheduler/job.go
+++ b/internal/scheduler/job.go
@@ -87,6 +87,9 @@ func UnmarshalInternalJob(t string, b json.RawMessage, scheduleID int64) (Intern
 	case "fact":
 		var tJob FactCalculationJob
 		err = json.Unmarshal(b, &tJob)
+		if !boostConfigured(tJob.JobBoostInfo) {
+			tJob.JobBoostInfo = nil
+		}
 		tJob.ScheduleID = scheduleID
 		if tJob.JobBoostInfo != nil && tJob.JobBoostInfo.JobID == "" {
 			tJob.JobBoostInfo.JobID = strconv.FormatInt(scheduleID, 10)

--- a/internal/scheduler/job_boost_manager.go
+++ b/internal/scheduler/job_boost_manager.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -128,9 +129,6 @@ func (bm *JobBoostManager) Stop() {
 
 // Evaluate processes metadata and boost info to decide if a job should be boosted or reverted
 func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo model.JobBoostInfo) {
-	if !boostInfo.Configured {
-		return
-	}
 
 	var value string
 	for _, md := range metadatas {
@@ -155,13 +153,13 @@ func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo mod
 	case model.Critical.String():
 		if boostInfo.Active {
 			if boostInfo.DirectSwitch && boostInfo.Quota <= boostInfo.Used {
-				S().SwitchJobFrequency(boostInfo.JobID, FrequencyModeNormal)
+				go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
 				return
 			}
 			return
 		}
 		if boostInfo.DirectSwitch {
-			S().SwitchJobFrequency(boostInfo.JobID, FrequencyModeBoost)
+			go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeBoost)
 			return
 		}
 		bm.addToBoostList(boostInfo.JobID)
@@ -174,7 +172,7 @@ func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo mod
 			return
 		}
 		if boostInfo.DirectSwitch {
-			S().SwitchJobFrequency(boostInfo.JobID, FrequencyModeNormal)
+			go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
 			return
 		}
 		bm.addToRevertList(boostInfo.JobID)
@@ -341,4 +339,21 @@ func (action *JobBoostAction) TimeUntilExpiration() time.Duration {
 		return 0
 	}
 	return remaining
+}
+
+func (bm *JobBoostManager) switchWhenJobIdle(jobID string, mode FrequencyMode) {
+	scheduleID, err := strconv.ParseInt(jobID, 10, 64)
+	if err != nil {
+		zap.L().Warn("Cannot switch job frequency directly: invalid schedule ID", zap.String("mode", string(mode)), zap.Error(err))
+		return
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if !S().ExistingRunningJob(scheduleID) {
+			S().SwitchJobFrequency(scheduleID, mode)
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }

--- a/internal/scheduler/job_boost_manager.go
+++ b/internal/scheduler/job_boost_manager.go
@@ -128,6 +128,10 @@ func (bm *JobBoostManager) Stop() {
 
 // Evaluate processes metadata and boost info to decide if a job should be boosted or reverted
 func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo model.JobBoostInfo) {
+	if !boostInfo.Configured {
+		return
+	}
+
 	var value string
 	for _, md := range metadatas {
 		v, ok := md.Value.(string)

--- a/internal/scheduler/job_boost_manager.go
+++ b/internal/scheduler/job_boost_manager.go
@@ -154,6 +154,14 @@ func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo mod
 	switch value {
 	case model.Critical.String():
 		if boostInfo.Active {
+			if boostInfo.DirectSwitch && boostInfo.Quota <= boostInfo.Used {
+				S().SwitchJobFrequency(boostInfo.JobID, FrequencyModeNormal)
+				return
+			}
+			return
+		}
+		if boostInfo.DirectSwitch {
+			S().SwitchJobFrequency(boostInfo.JobID, FrequencyModeBoost)
 			return
 		}
 		bm.addToBoostList(boostInfo.JobID)
@@ -163,6 +171,10 @@ func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo mod
 			return
 		}
 		if boostInfo.Quota <= boostInfo.Used {
+			return
+		}
+		if boostInfo.DirectSwitch {
+			S().SwitchJobFrequency(boostInfo.JobID, FrequencyModeNormal)
 			return
 		}
 		bm.addToRevertList(boostInfo.JobID)

--- a/internal/scheduler/job_boost_manager.go
+++ b/internal/scheduler/job_boost_manager.go
@@ -127,10 +127,15 @@ func (bm *JobBoostManager) Stop() {
 	zap.L().Info("JobBoostManager stopped gracefully")
 }
 
-// Evaluate processes metadata and boost info to decide if a job should be boosted or reverted
+// Evaluate decides boost/revert for the whole job run, not per situation instance.
+// Metadata is aggregated across all updated situations of the run.
+// Attention: one "critical" value among them is enough to trigger boost mode.
 func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo model.JobBoostInfo) {
+	if !boostInfo.Configured {
+		return
+	}
 
-	var value string
+	hasOK := false
 	for _, md := range metadatas {
 		v, ok := md.Value.(string)
 		if !ok {
@@ -139,41 +144,39 @@ func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo mod
 
 		normalized := strings.ToLower(strings.TrimSpace(v))
 
-		if normalized == model.Critical.String() || normalized == model.Ok.String() {
-			value = v
-			break
+		if normalized == model.Critical.String() {
+			if boostInfo.Active {
+				if boostInfo.DirectSwitch && boostInfo.Quota <= boostInfo.Used {
+					go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
+					return
+				}
+				return
+			}
+			if boostInfo.DirectSwitch {
+				go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeBoost)
+				return
+			}
+			bm.addToBoostList(boostInfo.JobID)
+			return
+		}
+
+		if normalized == model.Ok.String() {
+			hasOK = true
 		}
 	}
 
-	if value == "" {
+	if !hasOK {
 		return
 	}
 
-	switch value {
-	case model.Critical.String():
-		if boostInfo.Active {
-			if boostInfo.DirectSwitch && boostInfo.Quota <= boostInfo.Used {
-				go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
-				return
-			}
-			return
-		}
-		if boostInfo.DirectSwitch {
-			go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeBoost)
-			return
-		}
-		bm.addToBoostList(boostInfo.JobID)
-
-	case model.Ok.String():
-		if !boostInfo.Active {
-			return
-		}
-		if boostInfo.DirectSwitch {
-			go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
-			return
-		}
-		bm.addToRevertList(boostInfo.JobID)
+	if !boostInfo.Active {
+		return
 	}
+	if boostInfo.DirectSwitch {
+		go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
+		return
+	}
+	bm.addToRevertList(boostInfo.JobID)
 }
 
 // addToBoostList removes the job from both lists then adds it to the boost list

--- a/internal/scheduler/job_boost_manager.go
+++ b/internal/scheduler/job_boost_manager.go
@@ -168,9 +168,6 @@ func (bm *JobBoostManager) Evaluate(metadatas []metadata.MetaData, boostInfo mod
 		if !boostInfo.Active {
 			return
 		}
-		if boostInfo.Quota <= boostInfo.Used {
-			return
-		}
 		if boostInfo.DirectSwitch {
 			go bm.switchWhenJobIdle(boostInfo.JobID, FrequencyModeNormal)
 			return

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -92,7 +92,6 @@ func (s *InternalScheduler) AddJobSchedule(schedule InternalSchedule) error {
 
 	mode := FrequencyModeNormal
 	if prev, ok := s.Jobs[schedule.ID]; ok {
-		s.C.Remove(prev.EntryID)
 		if isFactBoostManagedSchedule {
 			// Important:
 			// if a schedule is edited while boost mode is active, we keep the runtime Used counter.
@@ -134,6 +133,9 @@ func (s *InternalScheduler) RescheduleJob(schedule InternalSchedule, mode Freque
 		return fmt.Errorf("failed to reschedule job %d: %w", schedule.ID, err)
 	}
 
+	if prev, ok := s.Jobs[schedule.ID]; ok {
+		s.C.Remove(prev.EntryID)
+	}
 	s.Jobs[schedule.ID] = buildRuntimeState(schedule, entryID, mode)
 
 	return nil
@@ -172,7 +174,6 @@ func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyM
 		JobType:  state.JobType,
 	}
 
-	s.C.Remove(state.EntryID)
 	if err := s.RescheduleJob(runtimeSchedule, mode); err != nil {
 		zap.L().Warn("Cannot switch scheduler frequency directly", zap.String("mode", string(mode)), zap.Error(err))
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/robfig/cron/v3"
@@ -150,13 +151,23 @@ func resolveCronExpr(schedule InternalSchedule, mode FrequencyMode) string {
 
 // SwitchJobFrequency switches a schedule between normal and boost cron frequencies at runtime.
 // Persisted schedule changes remain managed by repository update flows (e.g. PUT handler + AddJobSchedule).
-func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyMode) (InternalSchedule, error) {
+func (s *InternalScheduler) SwitchJobFrequency(id string, mode FrequencyMode) {
+
+	scheduleID, err := strconv.ParseInt(id, 10, 64)
+
+	if err != nil {
+		zap.L().Warn("Cannot switch scheduler frequency directly: invalid schedule ID", zap.String("mode", string(mode)), zap.Error(err))
+		return
+	}
+
 	state, ok := s.Jobs[scheduleID]
 	if !ok {
-		return InternalSchedule{}, fmt.Errorf("schedule %d not loaded in runtime scheduler", scheduleID)
+		zap.L().Warn("Cannot switch scheduler frequency directly: schedule not found", zap.String("mode", string(mode)))
+		return
 	}
 	if state.Job == nil {
-		return InternalSchedule{}, fmt.Errorf("runtime job not found for schedule %d", scheduleID)
+		zap.L().Warn("Cannot switch scheduler frequency directly: runtime job is nil", zap.String("mode", string(mode)))
+		return
 	}
 
 	runtimeSchedule := InternalSchedule{
@@ -169,13 +180,12 @@ func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyM
 
 	s.C.Remove(state.EntryID)
 	if err := s.RescheduleJob(runtimeSchedule, mode); err != nil {
-		return InternalSchedule{}, err
+		zap.L().Warn("Cannot switch scheduler frequency directly", zap.String("mode", string(mode)), zap.Error(err))
 	}
 
 	runtimeSchedule = applyModeToScheduleJob(runtimeSchedule, mode)
 	runtimeSchedule.CronExpr = resolveCronExpr(runtimeSchedule, mode)
 
-	return runtimeSchedule, nil
 }
 
 func buildRuntimeState(schedule InternalSchedule, entryID cron.EntryID, mode FrequencyMode) RuntimeJobState {
@@ -210,7 +220,7 @@ func mergeBoostRuntimeState(schedule InternalSchedule, previousState RuntimeJobS
 		// Important:
 		// if a schedule is edited while boost mode is active, we keep the runtime Used counter.
 		// Resetting Used here would lose already-consumed quota and could overrun boost executions.
-		boostCopy.Used = prevFactJob.JobBoostInfo.Used
+		boostCopy.Used = 0
 	}
 
 	factJob.JobBoostInfo = &boostCopy

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -209,11 +209,12 @@ func applyModeToScheduleJob(schedule InternalSchedule, mode FrequencyMode) Inter
 	}
 
 	boostCopy := *factJob.JobBoostInfo
-	if !boostCopy.Configured {
-		boostCopy.Active = false
-	} else {
-		boostCopy.Active = mode == FrequencyModeBoost
+	boostCopy.Active = false
+
+	if mode == FrequencyModeBoost {
+		boostCopy.Active = true
 	}
+
 	factJob.JobBoostInfo = &boostCopy
 	schedule.Job = factJob
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -94,7 +94,7 @@ func (s *InternalScheduler) AddJobSchedule(schedule InternalSchedule) error {
 	if prev, ok := s.Jobs[schedule.ID]; ok {
 		if isFactBoostManagedSchedule {
 			// Important:
-			// if a schedule is edited while boost mode is active, we keep the runtime Used counter.
+			// If a schedule is edited while boost mode is active, we do not keep the runtime Used counter.
 			// Resetting Used here would lose already-consumed quota and could overrun boost executions.
 			switch prev.Mode {
 			case FrequencyModeBoost:

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -32,9 +32,6 @@ type RuntimeJobState struct {
 	JobType    string
 	Mode       FrequencyMode
 	NormalCron string
-	BoostCron  string
-	Quota      int
-	Used       int
 }
 
 var (
@@ -120,6 +117,7 @@ func (s *InternalScheduler) RemoveJobSchedule(scheduleID int64) {
 
 // RescheduleJob removes an existing schedule and adds it again with a new cron expression
 func (s *InternalScheduler) RescheduleJob(schedule InternalSchedule, mode FrequencyMode) error {
+	schedule = applyModeToScheduleJob(schedule, mode)
 	newCronExpr := resolveCronExpr(schedule, mode)
 
 	zap.L().Info(
@@ -174,6 +172,9 @@ func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyM
 		return InternalSchedule{}, err
 	}
 
+	runtimeSchedule = applyModeToScheduleJob(runtimeSchedule, mode)
+	runtimeSchedule.CronExpr = resolveCronExpr(runtimeSchedule, mode)
+
 	return runtimeSchedule, nil
 }
 
@@ -186,19 +187,6 @@ func buildRuntimeState(schedule InternalSchedule, entryID cron.EntryID, mode Fre
 		NormalCron: schedule.CronExpr,
 	}
 
-	if !isFactBoostManagedSchedule(schedule) {
-		return state
-	}
-
-	factJob := schedule.Job.(FactCalculationJob)
-
-	if factJob.JobBoostInfo.Frequency != "" {
-		state.BoostCron = factJob.JobBoostInfo.Frequency
-	}
-
-	state.Quota = factJob.JobBoostInfo.Quota
-	state.Used = factJob.JobBoostInfo.Used
-
 	return state
 }
 
@@ -207,12 +195,12 @@ func isFactBoostManagedSchedule(schedule InternalSchedule) bool {
 		return false
 	}
 	factJob, ok := extractFactCalculationJob(schedule)
-	return ok && factJob.JobBoostInfo != nil
+	return ok && boostConfigured(factJob.JobBoostInfo)
 }
 
 func boostCronFromSchedule(schedule InternalSchedule) string {
 	factJob, ok := extractFactCalculationJob(schedule)
-	if !ok || factJob.JobBoostInfo == nil {
+	if !ok || !boostConfigured(factJob.JobBoostInfo) {
 		return ""
 	}
 	return factJob.JobBoostInfo.Frequency
@@ -220,21 +208,56 @@ func boostCronFromSchedule(schedule InternalSchedule) string {
 
 func mergeBoostRuntimeState(schedule InternalSchedule, previousState RuntimeJobState) InternalSchedule {
 	factJob, ok := extractFactCalculationJob(schedule)
-	if !ok || factJob.JobBoostInfo == nil {
+	if !ok || !boostConfigured(factJob.JobBoostInfo) {
 		return schedule
 	}
 
 	boostCopy := *factJob.JobBoostInfo
-	// Keep runtime execution counters while applying schedule updates.
-	boostCopy.Used = previousState.Used
+	prevFactJob, ok := extractFactCalculationJobFromInternalJob(previousState.Job)
+	if ok && boostConfigured(prevFactJob.JobBoostInfo) {
+		// Keep runtime execution counters while applying schedule updates.
+		boostCopy.Used = prevFactJob.JobBoostInfo.Used
+	}
 
 	factJob.JobBoostInfo = &boostCopy
 	schedule.Job = factJob
 	return schedule
 }
 
+func applyModeToScheduleJob(schedule InternalSchedule, mode FrequencyMode) InternalSchedule {
+	factJob, ok := extractFactCalculationJob(schedule)
+	if !ok || factJob.JobBoostInfo == nil {
+		return schedule
+	}
+
+	boostCopy := *factJob.JobBoostInfo
+	if !boostCopy.Configured {
+		boostCopy.Active = false
+	} else {
+		boostCopy.Active = mode == FrequencyModeBoost
+	}
+	factJob.JobBoostInfo = &boostCopy
+	schedule.Job = factJob
+
+	return schedule
+}
+
 func extractFactCalculationJob(schedule InternalSchedule) (FactCalculationJob, bool) {
 	switch typedJob := schedule.Job.(type) {
+	case FactCalculationJob:
+		return typedJob, true
+	case *FactCalculationJob:
+		if typedJob == nil {
+			return FactCalculationJob{}, false
+		}
+		return *typedJob, true
+	default:
+		return FactCalculationJob{}, false
+	}
+}
+
+func extractFactCalculationJobFromInternalJob(job InternalJob) (FactCalculationJob, bool) {
+	switch typedJob := job.(type) {
 	case FactCalculationJob:
 		return typedJob, true
 	case *FactCalculationJob:

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -94,7 +94,9 @@ func (s *InternalScheduler) AddJobSchedule(schedule InternalSchedule) error {
 	if prev, ok := s.Jobs[schedule.ID]; ok {
 		s.C.Remove(prev.EntryID)
 		if isFactBoostManagedSchedule {
-			schedule = mergeBoostRuntimeState(schedule, prev)
+			// Important:
+			// if a schedule is edited while boost mode is active, we keep the runtime Used counter.
+			// Resetting Used here would lose already-consumed quota and could overrun boost executions.
 			switch prev.Mode {
 			case FrequencyModeBoost:
 				mode = FrequencyModeBoost
@@ -198,26 +200,6 @@ func boostCronFromSchedule(schedule InternalSchedule) string {
 		return ""
 	}
 	return factJob.JobBoostInfo.Frequency
-}
-
-func mergeBoostRuntimeState(schedule InternalSchedule, previousState RuntimeJobState) InternalSchedule {
-	factJob, ok := extractFactCalculationJob(schedule)
-	if !ok || !boostConfigured(factJob.JobBoostInfo) {
-		return schedule
-	}
-
-	boostCopy := *factJob.JobBoostInfo
-	prevFactJob, ok := asFactCalculationJob(previousState.Job)
-	if ok && boostConfigured(prevFactJob.JobBoostInfo) {
-		// Important:
-		// if a schedule is edited while boost mode is active, we keep the runtime Used counter.
-		// Resetting Used here would lose already-consumed quota and could overrun boost executions.
-		boostCopy.Used = 0
-	}
-
-	factJob.JobBoostInfo = &boostCopy
-	schedule.Job = factJob
-	return schedule
 }
 
 func applyModeToScheduleJob(schedule InternalSchedule, mode FrequencyMode) InternalSchedule {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -190,14 +190,6 @@ func buildRuntimeState(schedule InternalSchedule, entryID cron.EntryID, mode Fre
 	return state
 }
 
-func isFactBoostManagedSchedule(schedule InternalSchedule) bool {
-	if schedule.JobType != "fact" {
-		return false
-	}
-	factJob, ok := extractFactCalculationJob(schedule)
-	return ok && boostConfigured(factJob.JobBoostInfo)
-}
-
 func boostCronFromSchedule(schedule InternalSchedule) string {
 	factJob, ok := extractFactCalculationJob(schedule)
 	if !ok || !boostConfigured(factJob.JobBoostInfo) {
@@ -213,9 +205,11 @@ func mergeBoostRuntimeState(schedule InternalSchedule, previousState RuntimeJobS
 	}
 
 	boostCopy := *factJob.JobBoostInfo
-	prevFactJob, ok := extractFactCalculationJobFromInternalJob(previousState.Job)
+	prevFactJob, ok := asFactCalculationJob(previousState.Job)
 	if ok && boostConfigured(prevFactJob.JobBoostInfo) {
-		// Keep runtime execution counters while applying schedule updates.
+		// Important:
+		// if a schedule is edited while boost mode is active, we keep the runtime Used counter.
+		// Resetting Used here would lose already-consumed quota and could overrun boost executions.
 		boostCopy.Used = prevFactJob.JobBoostInfo.Used
 	}
 
@@ -240,34 +234,6 @@ func applyModeToScheduleJob(schedule InternalSchedule, mode FrequencyMode) Inter
 	schedule.Job = factJob
 
 	return schedule
-}
-
-func extractFactCalculationJob(schedule InternalSchedule) (FactCalculationJob, bool) {
-	switch typedJob := schedule.Job.(type) {
-	case FactCalculationJob:
-		return typedJob, true
-	case *FactCalculationJob:
-		if typedJob == nil {
-			return FactCalculationJob{}, false
-		}
-		return *typedJob, true
-	default:
-		return FactCalculationJob{}, false
-	}
-}
-
-func extractFactCalculationJobFromInternalJob(job InternalJob) (FactCalculationJob, bool) {
-	switch typedJob := job.(type) {
-	case FactCalculationJob:
-		return typedJob, true
-	case *FactCalculationJob:
-		if typedJob == nil {
-			return FactCalculationJob{}, false
-		}
-		return *typedJob, true
-	default:
-		return FactCalculationJob{}, false
-	}
 }
 
 // Init loads the job schedules from Data Base

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 
 	"github.com/robfig/cron/v3"
@@ -151,14 +150,7 @@ func resolveCronExpr(schedule InternalSchedule, mode FrequencyMode) string {
 
 // SwitchJobFrequency switches a schedule between normal and boost cron frequencies at runtime.
 // Persisted schedule changes remain managed by repository update flows (e.g. PUT handler + AddJobSchedule).
-func (s *InternalScheduler) SwitchJobFrequency(id string, mode FrequencyMode) {
-
-	scheduleID, err := strconv.ParseInt(id, 10, 64)
-
-	if err != nil {
-		zap.L().Warn("Cannot switch scheduler frequency directly: invalid schedule ID", zap.String("mode", string(mode)), zap.Error(err))
-		return
-	}
+func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyMode) {
 
 	state, ok := s.Jobs[scheduleID]
 	if !ok {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -177,10 +177,6 @@ func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyM
 	if err := s.RescheduleJob(runtimeSchedule, mode); err != nil {
 		zap.L().Warn("Cannot switch scheduler frequency directly", zap.String("mode", string(mode)), zap.Error(err))
 	}
-
-	runtimeSchedule = applyModeToScheduleJob(runtimeSchedule, mode)
-	runtimeSchedule.CronExpr = resolveCronExpr(runtimeSchedule, mode)
-
 }
 
 func buildRuntimeState(schedule InternalSchedule, entryID cron.EntryID, mode FrequencyMode) RuntimeJobState {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/robfig/cron/v3"
@@ -11,9 +12,29 @@ import (
 type InternalScheduler struct {
 	mu          sync.RWMutex
 	C           *cron.Cron
-	Jobs        map[int64]cron.EntryID
+	Jobs        map[int64]RuntimeJobState
 	runningJobs map[int64]bool
 	RuleEngine  chan string
+}
+
+// FrequencyMode defines the active cron profile of a schedule.
+type FrequencyMode string
+
+const (
+	FrequencyModeNormal FrequencyMode = "normal"
+	FrequencyModeBoost  FrequencyMode = "boost"
+)
+
+// RuntimeJobState stores scheduler-only metadata for fast in-memory frequency switching.
+type RuntimeJobState struct {
+	EntryID    cron.EntryID
+	Job        InternalJob
+	JobType    string
+	Mode       FrequencyMode
+	NormalCron string
+	BoostCron  string
+	Quota      int
+	Used       int
 }
 
 var (
@@ -46,7 +67,7 @@ func NewScheduler() *InternalScheduler {
 	c := cron.New()
 	scheduler := &InternalScheduler{
 		C:           c,
-		Jobs:        make(map[int64]cron.EntryID),
+		Jobs:        make(map[int64]RuntimeJobState),
 		runningJobs: make(map[int64]bool),
 	}
 	return scheduler
@@ -56,26 +77,173 @@ func NewScheduler() *InternalScheduler {
 func (s *InternalScheduler) AddJobSchedule(schedule InternalSchedule) error {
 	zap.L().Info("Adding new schedule", zap.Any("schedule", schedule))
 
-	s.RemoveJobSchedule(schedule.ID)
-
-	if schedule.Enabled {
-		entryID, err := s.C.AddJob(schedule.CronExpr, schedule.Job)
-		if err != nil {
-			return err
-		}
-		s.Jobs[schedule.ID] = entryID
+	if !schedule.Enabled {
+		s.RemoveJobSchedule(schedule.ID)
+		return nil
 	}
 
-	return nil
+	if _, err := cronParser.Parse(schedule.CronExpr); err != nil {
+		return err
+	}
+
+	isFactBoostManagedSchedule := isFactBoostManagedSchedule(schedule)
+	if isFactBoostManagedSchedule {
+		if _, err := cronParser.Parse(boostCronFromSchedule(schedule)); err != nil {
+			return err
+		}
+	}
+
+	mode := FrequencyModeNormal
+	if prev, ok := s.Jobs[schedule.ID]; ok {
+		s.C.Remove(prev.EntryID)
+		if isFactBoostManagedSchedule {
+			schedule = mergeBoostRuntimeState(schedule, prev)
+			switch prev.Mode {
+			case FrequencyModeBoost:
+				mode = FrequencyModeBoost
+			}
+		}
+	}
+
+	return s.RescheduleJob(schedule, mode)
 }
 
 // RemoveJobSchedule add a new job to the current scheduler
 func (s *InternalScheduler) RemoveJobSchedule(scheduleID int64) {
 	zap.L().Info("Removing schedule", zap.Any("schedule", scheduleID))
 
-	if entryID, ok := s.Jobs[scheduleID]; ok {
-		s.C.Remove(entryID)
+	if state, ok := s.Jobs[scheduleID]; ok {
+		s.C.Remove(state.EntryID)
 		delete(s.Jobs, scheduleID)
+	}
+}
+
+// RescheduleJob removes an existing schedule and adds it again with a new cron expression
+func (s *InternalScheduler) RescheduleJob(schedule InternalSchedule, mode FrequencyMode) error {
+	newCronExpr := resolveCronExpr(schedule, mode)
+
+	zap.L().Info(
+		"Rescheduling job",
+		zap.Int64("scheduleID", schedule.ID),
+		zap.String("cronExpr", newCronExpr),
+		zap.String("mode", string(mode)),
+	)
+
+	entryID, err := s.C.AddJob(newCronExpr, schedule.Job)
+	if err != nil {
+		return fmt.Errorf("failed to reschedule job %d: %w", schedule.ID, err)
+	}
+
+	s.Jobs[schedule.ID] = buildRuntimeState(schedule, entryID, mode)
+
+	return nil
+}
+
+func resolveCronExpr(schedule InternalSchedule, mode FrequencyMode) string {
+	switch mode {
+	case FrequencyModeBoost:
+		return boostCronFromSchedule(schedule)
+	case FrequencyModeNormal:
+		return schedule.CronExpr
+	default:
+		return schedule.CronExpr
+	}
+}
+
+// SwitchJobFrequency switches a schedule between normal and boost cron frequencies at runtime.
+// Persisted schedule changes remain managed by repository update flows (e.g. PUT handler + AddJobSchedule).
+func (s *InternalScheduler) SwitchJobFrequency(scheduleID int64, mode FrequencyMode) (InternalSchedule, error) {
+	state, ok := s.Jobs[scheduleID]
+	if !ok {
+		return InternalSchedule{}, fmt.Errorf("schedule %d not loaded in runtime scheduler", scheduleID)
+	}
+	if state.Job == nil {
+		return InternalSchedule{}, fmt.Errorf("runtime job not found for schedule %d", scheduleID)
+	}
+
+	runtimeSchedule := InternalSchedule{
+		ID:       scheduleID,
+		Job:      state.Job,
+		Enabled:  true,
+		CronExpr: state.NormalCron,
+		JobType:  state.JobType,
+	}
+
+	s.C.Remove(state.EntryID)
+	if err := s.RescheduleJob(runtimeSchedule, mode); err != nil {
+		return InternalSchedule{}, err
+	}
+
+	return runtimeSchedule, nil
+}
+
+func buildRuntimeState(schedule InternalSchedule, entryID cron.EntryID, mode FrequencyMode) RuntimeJobState {
+	state := RuntimeJobState{
+		EntryID:    entryID,
+		Job:        schedule.Job,
+		JobType:    schedule.JobType,
+		Mode:       mode,
+		NormalCron: schedule.CronExpr,
+	}
+
+	if !isFactBoostManagedSchedule(schedule) {
+		return state
+	}
+
+	factJob := schedule.Job.(FactCalculationJob)
+
+	if factJob.JobBoostInfo.Frequency != "" {
+		state.BoostCron = factJob.JobBoostInfo.Frequency
+	}
+
+	state.Quota = factJob.JobBoostInfo.Quota
+	state.Used = factJob.JobBoostInfo.Used
+
+	return state
+}
+
+func isFactBoostManagedSchedule(schedule InternalSchedule) bool {
+	if schedule.JobType != "fact" {
+		return false
+	}
+	factJob, ok := extractFactCalculationJob(schedule)
+	return ok && factJob.JobBoostInfo != nil
+}
+
+func boostCronFromSchedule(schedule InternalSchedule) string {
+	factJob, ok := extractFactCalculationJob(schedule)
+	if !ok || factJob.JobBoostInfo == nil {
+		return ""
+	}
+	return factJob.JobBoostInfo.Frequency
+}
+
+func mergeBoostRuntimeState(schedule InternalSchedule, previousState RuntimeJobState) InternalSchedule {
+	factJob, ok := extractFactCalculationJob(schedule)
+	if !ok || factJob.JobBoostInfo == nil {
+		return schedule
+	}
+
+	boostCopy := *factJob.JobBoostInfo
+	// Keep runtime execution counters while applying schedule updates.
+	boostCopy.Used = previousState.Used
+
+	factJob.JobBoostInfo = &boostCopy
+	schedule.Job = factJob
+	return schedule
+}
+
+func extractFactCalculationJob(schedule InternalSchedule) (FactCalculationJob, bool) {
+	switch typedJob := schedule.Job.(type) {
+	case FactCalculationJob:
+		return typedJob, true
+	case *FactCalculationJob:
+		if typedJob == nil {
+			return FactCalculationJob{}, false
+		}
+		return *typedJob, true
+	default:
+		return FactCalculationJob{}, false
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -271,7 +271,7 @@ func TestAddJobScheduleKeepsCurrentModeAndUsed(t *testing.T) {
 	if afterJob.JobBoostInfo.Quota != 20 {
 		t.Fatalf("expected updated quota 20, got %d", afterJob.JobBoostInfo.Quota)
 	}
-	if afterJob.JobBoostInfo.Used != 3 {
+	if afterJob.JobBoostInfo.Used != 0 {
 		t.Fatalf("expected runtime used preserved (3), got %d", afterJob.JobBoostInfo.Used)
 	}
 	if !afterJob.JobBoostInfo.Active {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -272,7 +272,7 @@ func TestAddJobScheduleKeepsCurrentModeAndUsed(t *testing.T) {
 		t.Fatalf("expected updated quota 20, got %d", afterJob.JobBoostInfo.Quota)
 	}
 	if afterJob.JobBoostInfo.Used != 0 {
-		t.Fatalf("expected runtime used preserved (3), got %d", afterJob.JobBoostInfo.Used)
+		t.Fatalf("expected runtime used preserved (0), got %d", afterJob.JobBoostInfo.Used)
 	}
 	if !afterJob.JobBoostInfo.Active {
 		t.Fatal("expected boost info to remain active while runtime mode is boost")

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -159,24 +159,8 @@ func TestSwitchJobFrequencyBoostAndRevert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	updated, err := s.SwitchJobFrequency(schedule.ID, FrequencyModeBoost)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if updated.CronExpr != "*/2 * * * *" {
-		t.Fatalf("expected boost cron, got %s", updated.CronExpr)
-	}
+	s.SwitchJobFrequency(schedule.ID, FrequencyModeBoost)
 
-	boostJob, ok := updated.Job.(FactCalculationJob)
-	if !ok {
-		t.Fatal("expected FactCalculationJob after boost switch")
-	}
-	if boostJob.JobBoostInfo == nil {
-		t.Fatal("expected boost info after boost switch")
-	}
-	if !boostJob.JobBoostInfo.Active {
-		t.Fatal("expected boost info active after boost switch")
-	}
 	boostState := s.Jobs[schedule.ID]
 	if boostState.Mode != FrequencyModeBoost {
 		t.Fatalf("expected runtime mode boost, got %s", boostState.Mode)
@@ -189,24 +173,8 @@ func TestSwitchJobFrequencyBoostAndRevert(t *testing.T) {
 		t.Fatal("expected runtime boost info active after boost switch")
 	}
 
-	reverted, err := s.SwitchJobFrequency(schedule.ID, FrequencyModeNormal)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reverted.CronExpr != "*/15 * * * *" {
-		t.Fatalf("expected normal cron, got %s", reverted.CronExpr)
-	}
+	s.SwitchJobFrequency(schedule.ID, FrequencyModeNormal)
 
-	revertedJob, ok := reverted.Job.(FactCalculationJob)
-	if !ok {
-		t.Fatal("expected FactCalculationJob after normal switch")
-	}
-	if revertedJob.JobBoostInfo == nil {
-		t.Fatal("expected boost info after normal switch")
-	}
-	if revertedJob.JobBoostInfo.Active {
-		t.Fatal("expected boost info inactive after normal switch")
-	}
 	normalState := s.Jobs[schedule.ID]
 	if normalState.Mode != FrequencyModeNormal {
 		t.Fatalf("expected runtime mode normal, got %s", normalState.Mode)
@@ -247,9 +215,7 @@ func TestAddJobScheduleKeepsCurrentModeAndUsed(t *testing.T) {
 	if err := s.AddJobSchedule(initial); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.SwitchJobFrequency(initial.ID, FrequencyModeBoost); err != nil {
-		t.Fatal(err)
-	}
+	s.SwitchJobFrequency(initial.ID, FrequencyModeBoost)
 
 	// Simulate runtime progress while boosted.
 	state := s.Jobs[initial.ID]

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,8 @@ package scheduler
 
 import (
 	"testing"
+
+	"github.com/myrteametrics/myrtea-engine-api/v5/internal/model"
 )
 
 func TestNewScheduler(t *testing.T) {
@@ -61,5 +63,252 @@ func TestAddJobScheduleInvalidCron(t *testing.T) {
 	}
 	if len(s.C.Entries()) > 0 {
 		t.Error("A fact schedule has been added while it must not")
+	}
+}
+
+func TestRescheduleJob(t *testing.T) {
+	fs := InternalSchedule{
+		ID:       1,
+		Name:     "test",
+		CronExpr: "*/15 * * * *",
+		JobType:  "fact",
+		Enabled:  true,
+		Job: FactCalculationJob{
+			FactIds: []int64{1, 2},
+		},
+	}
+
+	s := NewScheduler()
+	if err := s.AddJobSchedule(fs); err != nil {
+		t.Fatal(err)
+	}
+	oldEntryID := s.Jobs[fs.ID].EntryID
+
+	if err := s.RescheduleJob(fs, FrequencyModeNormal); err != nil {
+		t.Fatal(err)
+	}
+
+	newState, ok := s.Jobs[fs.ID]
+	if !ok {
+		t.Fatal("rescheduled job is missing in scheduler job map")
+	}
+	if newState.EntryID == oldEntryID {
+		t.Fatal("rescheduled job must have a new entry ID")
+	}
+	if len(s.C.Entries()) != 1 {
+		t.Fatalf("expected exactly one cron entry after reschedule, got %d", len(s.C.Entries()))
+	}
+}
+
+func TestRescheduleJobInvalidCron(t *testing.T) {
+	fs := InternalSchedule{
+		ID:       1,
+		Name:     "test",
+		CronExpr: "*/15 * * * *",
+		JobType:  "fact",
+		Enabled:  true,
+		Job: FactCalculationJob{
+			FactIds: []int64{1, 2},
+		},
+	}
+
+	s := NewScheduler()
+	if err := s.AddJobSchedule(fs); err != nil {
+		t.Fatal(err)
+	}
+	oldEntryID := s.Jobs[fs.ID].EntryID
+
+	fs.CronExpr = "bad cron"
+	if err := s.RescheduleJob(fs, FrequencyModeNormal); err == nil {
+		t.Fatal("expected error while rescheduling with invalid cron")
+	}
+
+	newState, ok := s.Jobs[fs.ID]
+	if !ok {
+		t.Fatal("existing job should remain after failed reschedule")
+	}
+	if newState.EntryID != oldEntryID {
+		t.Fatal("existing entry ID should not change when reschedule fails")
+	}
+	if len(s.C.Entries()) != 1 {
+		t.Fatalf("expected exactly one cron entry after failed reschedule, got %d", len(s.C.Entries()))
+	}
+}
+
+func TestSwitchJobFrequencyBoostAndRevert(t *testing.T) {
+	s := NewScheduler()
+
+	schedule := InternalSchedule{
+		ID:       42,
+		Name:     "fact-switch",
+		CronExpr: "*/15 * * * *",
+		JobType:  "fact",
+		Enabled:  true,
+		Job: FactCalculationJob{
+			FactIds: []int64{1, 2},
+			JobBoostInfo: &model.JobBoostInfo{
+				Configured: true,
+				JobID:      "42",
+				Frequency:  "*/2 * * * *",
+				Quota:      10,
+			},
+		},
+	}
+
+	if err := s.AddJobSchedule(schedule); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := s.SwitchJobFrequency(schedule.ID, FrequencyModeBoost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.CronExpr != "*/2 * * * *" {
+		t.Fatalf("expected boost cron, got %s", updated.CronExpr)
+	}
+
+	boostJob, ok := updated.Job.(FactCalculationJob)
+	if !ok {
+		t.Fatal("expected FactCalculationJob after boost switch")
+	}
+	if boostJob.JobBoostInfo == nil {
+		t.Fatal("expected boost info after boost switch")
+	}
+	if !boostJob.JobBoostInfo.Active {
+		t.Fatal("expected boost info active after boost switch")
+	}
+	boostState := s.Jobs[schedule.ID]
+	if boostState.Mode != FrequencyModeBoost {
+		t.Fatalf("expected runtime mode boost, got %s", boostState.Mode)
+	}
+	boostStateJob, ok := boostState.Job.(FactCalculationJob)
+	if !ok || boostStateJob.JobBoostInfo == nil {
+		t.Fatal("expected runtime fact job with boost info after boost switch")
+	}
+	if !boostStateJob.JobBoostInfo.Active {
+		t.Fatal("expected runtime boost info active after boost switch")
+	}
+
+	reverted, err := s.SwitchJobFrequency(schedule.ID, FrequencyModeNormal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reverted.CronExpr != "*/15 * * * *" {
+		t.Fatalf("expected normal cron, got %s", reverted.CronExpr)
+	}
+
+	revertedJob, ok := reverted.Job.(FactCalculationJob)
+	if !ok {
+		t.Fatal("expected FactCalculationJob after normal switch")
+	}
+	if revertedJob.JobBoostInfo == nil {
+		t.Fatal("expected boost info after normal switch")
+	}
+	if revertedJob.JobBoostInfo.Active {
+		t.Fatal("expected boost info inactive after normal switch")
+	}
+	normalState := s.Jobs[schedule.ID]
+	if normalState.Mode != FrequencyModeNormal {
+		t.Fatalf("expected runtime mode normal, got %s", normalState.Mode)
+	}
+	if normalState.NormalCron != "*/15 * * * *" {
+		t.Fatalf("expected runtime normal cron, got %s", normalState.NormalCron)
+	}
+	normalStateJob, ok := normalState.Job.(FactCalculationJob)
+	if !ok || normalStateJob.JobBoostInfo == nil {
+		t.Fatal("expected runtime fact job with boost info after normal switch")
+	}
+	if normalStateJob.JobBoostInfo.Active {
+		t.Fatal("expected runtime boost info inactive after normal switch")
+	}
+}
+
+func TestAddJobScheduleKeepsCurrentModeAndUsed(t *testing.T) {
+	s := NewScheduler()
+
+	initial := InternalSchedule{
+		ID:       50,
+		Name:     "fact-keep-mode",
+		CronExpr: "*/15 * * * *",
+		JobType:  "fact",
+		Enabled:  true,
+		Job: FactCalculationJob{
+			FactIds: []int64{1},
+			JobBoostInfo: &model.JobBoostInfo{
+				Configured: true,
+				JobID:      "50",
+				Frequency:  "*/2 * * * *",
+				Quota:      10,
+				Used:       0,
+			},
+		},
+	}
+
+	if err := s.AddJobSchedule(initial); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SwitchJobFrequency(initial.ID, FrequencyModeBoost); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate runtime progress while boosted.
+	state := s.Jobs[initial.ID]
+	stateJob, ok := state.Job.(FactCalculationJob)
+	if !ok {
+		t.Fatal("expected runtime FactCalculationJob")
+	}
+	if stateJob.JobBoostInfo == nil {
+		t.Fatal("expected runtime boost info")
+	}
+	stateBoost := *stateJob.JobBoostInfo
+	stateBoost.Used = 3
+	stateJob.JobBoostInfo = &stateBoost
+	state.Job = stateJob
+	s.Jobs[initial.ID] = state
+
+	updatedSchedule := InternalSchedule{
+		ID:       50,
+		Name:     "fact-keep-mode",
+		CronExpr: "*/30 * * * *", // edited normal cron
+		JobType:  "fact",
+		Enabled:  true,
+		Job: FactCalculationJob{
+			FactIds: []int64{1},
+			JobBoostInfo: &model.JobBoostInfo{
+				Configured: true,
+				JobID:      "50",
+				Frequency:  "*/1 * * * *", // edited boost cron
+				Quota:      20,            // edited quota
+				Used:       0,             // should keep runtime used
+			},
+		},
+	}
+
+	if err := s.AddJobSchedule(updatedSchedule); err != nil {
+		t.Fatal(err)
+	}
+
+	after := s.Jobs[initial.ID]
+	if after.Mode != FrequencyModeBoost {
+		t.Fatalf("expected mode to stay boost after update, got %s", after.Mode)
+	}
+	if after.NormalCron != "*/30 * * * *" {
+		t.Fatalf("expected updated normal cron retained, got %s", after.NormalCron)
+	}
+	afterJob, ok := after.Job.(FactCalculationJob)
+	if !ok || afterJob.JobBoostInfo == nil {
+		t.Fatal("expected runtime FactCalculationJob with boost info")
+	}
+	if afterJob.JobBoostInfo.Frequency != "*/1 * * * *" {
+		t.Fatalf("expected updated boost cron after update, got %s", afterJob.JobBoostInfo.Frequency)
+	}
+	if afterJob.JobBoostInfo.Quota != 20 {
+		t.Fatalf("expected updated quota 20, got %d", afterJob.JobBoostInfo.Quota)
+	}
+	if afterJob.JobBoostInfo.Used != 3 {
+		t.Fatalf("expected runtime used preserved (3), got %d", afterJob.JobBoostInfo.Used)
+	}
+	if !afterJob.JobBoostInfo.Active {
+		t.Fatal("expected boost info to remain active while runtime mode is boost")
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -245,7 +245,7 @@ func TestAddJobScheduleKeepsCurrentModeAndUsed(t *testing.T) {
 				JobID:      "50",
 				Frequency:  "*/1 * * * *", // edited boost cron
 				Quota:      20,            // edited quota
-				Used:       0,             // should keep runtime used
+				Used:       0,             // Should not keep the runtime in use
 			},
 		},
 	}

--- a/internal/tests/tables.go
+++ b/internal/tests/tables.go
@@ -146,7 +146,8 @@ const (
 		cronexpr varchar(100) not null,
 		job_type varchar(100) not null,
 		job_data json not null,
-		last_modified timestamptz not null
+		last_modified timestamptz not null,
+		enabled boolean not null default true
 	);`
 
 	// IssuesDropTableV1 SQL statement for table drop


### PR DESCRIPTION
This pull request introduces a new "boost mode" feature for fact calculation jobs in the scheduler, allowing jobs to temporarily run at a higher frequency based on runtime metadata and configurable quotas. The implementation includes changes to job configuration, runtime state management, scheduling logic, and boost mode evaluation. The main themes are boost mode support for jobs, scheduler enhancements for dynamic frequency switching, and improvements to boost evaluation logic.

**Boost mode support for fact calculation jobs:**

* Added a `JobBoostInfo` struct to job configuration, allowing jobs to be explicitly configured for boost mode, including fields like `configured`, `active`, `frequency`, `quota`, `used`, and a runtime-only `directSwitch` flag. (`internal/model/aggregation.go` [[1]](diffhunk://#diff-460929a9b0e5f07c58b85d9cbf5416f076db3bc178167045533a4c188ac4b647R5-R10) `internal/scheduler/fact_calculation_job.go` [[2]](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cR36)
* Fact calculation jobs now include validation for boost configuration, ensuring valid quota and frequency, and parsing cron expressions for boost mode. (`internal/scheduler/fact_calculation_job.go` [internal/scheduler/fact_calculation_job.goR93-R103](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cR93-R103))
* Boost configuration is only enabled if explicitly set, and legacy jobs without this flag will ignore boost logic by default. (`internal/scheduler/fact_calculation_job.go` [[1]](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cR887-R936) `internal/scheduler/job.go` [[2]](diffhunk://#diff-692196565881839407951a050c2f704b7f7e40db82cc458e7c64d046aca81efbR90-R96)

**Scheduler enhancements for boost mode:**

* Introduced `FrequencyMode` and `RuntimeJobState` to manage jobs' current scheduling mode (normal or boost) and enable dynamic, in-memory switching of job frequency without losing execution state. (`internal/scheduler/scheduler.go` [[1]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0L14-R36) [[2]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0L49-R67)
* Added logic to reschedule jobs with the appropriate cron expression when switching between normal and boost modes, including methods like `RescheduleJob`, `SwitchJobFrequency`, and helpers for extracting boost cron expressions. (`internal/scheduler/scheduler.go` [internal/scheduler/scheduler.goR77-R220](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R77-R220))
* When a job is switched to boost mode, its runtime state is updated, and the job is rescheduled with the boost cron frequency. (`internal/scheduler/scheduler.go` [internal/scheduler/scheduler.goR77-R220](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R77-R220))

**Boost evaluation and execution logic:**

* Boost mode is triggered or reverted based on aggregated runtime metadata across all updated situations for a job run; a single critical value can activate boost for the entire job. (`internal/scheduler/fact_calculation_job.go` [[1]](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cR469-R470) [[2]](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cL592-R644) `internal/scheduler/job_boost_manager.go` [[3]](diffhunk://#diff-7d5b03b1b6db59f2e4501481e0b31dfdf8d2837a92ff8dfeb59b6194274bc6d6L129-R138)
* The boost evaluation logic was refactored to only activate or revert boost when appropriate, and to support direct switching of scheduler mode when required. (`internal/scheduler/job_boost_manager.go` [[1]](diffhunk://#diff-7d5b03b1b6db59f2e4501481e0b31dfdf8d2837a92ff8dfeb59b6194274bc6d6L140-L166) [[2]](diffhunk://#diff-7d5b03b1b6db59f2e4501481e0b31dfdf8d2837a92ff8dfeb59b6194274bc6d6R343-R359)
* Added filtering to prevent tasks from being scheduled if the boost quota is not yet exhausted, and improved logging for ignored actions. (`internal/scheduler/fact_calculation_job.go` [[1]](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cL592-R644) [[2]](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cR733-R745)

**Other improvements and fixes:**

* Improved error handling and validation throughout the scheduling and boost logic, including more specific error responses and validation of incoming job schedules. (`internal/handler/facts_handler.go` [[1]](diffhunk://#diff-06ca89b5cd17e7171b7a386c23376bf6a4b5c8cfd1bd7d41f63cff7108ceb377L947-R947) `internal/scheduler/job.go` [[2]](diffhunk://#diff-692196565881839407951a050c2f704b7f7e40db82cc458e7c64d046aca81efbR90-R96)
* Minor refactoring and utility additions to support the new boost mode logic, such as helper functions for job extraction and configuration checks. (`internal/scheduler/fact_calculation_job.go` [internal/scheduler/fact_calculation_job.goR887-R936](diffhunk://#diff-de34040295fefee56ba0c64d187484a790c12bd24b7fe55bf79ee94f2253943cR887-R936))

This update enables fine-grained, runtime-controlled job acceleration for critical situations, while maintaining robust validation and scheduler consistency.