### PR TITLE
Add JWT extraction support for WebSocket subprotocol

### DIFF
--- a/internal/router/oidc/oidc_middleware.go
+++ b/internal/router/oidc/oidc_middleware.go
@@ -29,6 +29,8 @@ func OIDCMiddleware(next http.Handler) http.Handler {
 			tokenStr = strings.TrimPrefix(authHeader, tokenPrefix)
 		} else if r.URL.Query().Has(tokenKey) {
 			tokenStr = r.URL.Query().Get(tokenKey)
+		} else if ws := tokenFromWebSocketProtocol(r); ws != "" {
+			tokenStr = ws
 		} else {
 			zap.L().Warn("No token string found in request")
 			httputil.Error(w, r, httputil.ErrAPISecurityMissingContext, errors.New("missing token"))

--- a/internal/router/oidc/utils.go
+++ b/internal/router/oidc/utils.go
@@ -1,6 +1,30 @@
 package routeroidc
 
-const (
-	tokenPrefix = "Bearer "
-	tokenKey    = "jwt"
+import (
+	"net/http"
+	"strings"
 )
+
+const (
+	tokenPrefix       = "Bearer "
+	tokenKey          = "jwt"
+	wsAuthSubprotocol = "bearer"
+)
+
+// tokenFromWebSocketProtocol extracts a JWT from Sec-WebSocket-Protocol.
+// Browsers cannot set custom headers on a WS handshake, so the token is
+// passed as a subprotocol value alongside the sentinel "bearer" subprotocol.
+func tokenFromWebSocketProtocol(r *http.Request) string {
+	header := r.Header.Get("Sec-WebSocket-Protocol")
+	if header == "" {
+		return ""
+	}
+	for _, part := range strings.Split(header, ",") {
+		value := strings.TrimSpace(part)
+		if value == "" || value == wsAuthSubprotocol {
+			continue
+		}
+		return value
+	}
+	return ""
+}


### PR DESCRIPTION
This pull request enhances the OIDC middleware to support JWT extraction from WebSocket handshake requests. This allows clients using WebSockets, which cannot set custom headers, to authenticate by passing the JWT as a subprotocol value.

**WebSocket authentication support:**

* Added the `tokenFromWebSocketProtocol` function in `utils.go` to extract JWTs from the `Sec-WebSocket-Protocol` header, skipping the sentinel "bearer" subprotocol.
* Updated `OIDCMiddleware` in `oidc_middleware.go` to use the extracted token from WebSocket protocol if present, improving authentication for WebSocket connections.